### PR TITLE
HLS ingest service: Python + ffmpeg pipeline to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,13 @@ inc/
 /MANIFEST.bak
 /pm_to_blib
 /*.zip
+worklog/
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+*.egg-info/
+.eggs/
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,41 @@
 # WXYC-Archive
+
+Automated audio recording and archiving for WXYC 89.3 FM. Runs on a Raspberry Pi to capture the broadcast, encode it, and upload hourly segments to S3.
+
+## How It Works
+
+A cron job runs `record_audio.pl` every hour, which:
+
+1. Records 3600 seconds of audio from the sound card via `arecord`
+2. Encodes the recording to FLAC (local archive) and MP3
+3. Uploads the MP3 to the `s3://wxyc-archive/` bucket, organized by date
+4. Cleans up the temporary WAV file
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `record_audio.pl` | Main recording/encoding/upload script |
+| `cron_file` | Crontab entry that triggers hourly recording |
+
+## Prerequisites
+
+- Perl (with `DateTime`, `Getopt::Long`, `File::Spec`, `File::Path`)
+- `arecord` (ALSA utils) for audio capture
+- `flac` for FLAC encoding
+- `lame` for MP3 encoding
+- AWS CLI (configured with credentials for S3 uploads)
+
+## Usage
+
+Install the cron job:
+
+```bash
+crontab cron_file
+```
+
+Test with a short recording in debug mode:
+
+```bash
+./record_audio.pl -l 10 --debug
+```

--- a/hls-ingest/CLAUDE.md
+++ b/hls-ingest/CLAUDE.md
@@ -1,0 +1,48 @@
+# hls-ingest
+
+HLS ingest service that captures the WXYC ibiblio MP3 stream, segments it into HLS via ffmpeg, and uploads segments to S3.
+
+## Architecture
+
+- `main.py` -- Entry point. Orchestrates ffmpeg, S3 uploader, and health endpoint.
+- `config.py` -- Loads configuration from environment variables with defaults.
+- `ingest.py` -- Manages the ffmpeg subprocess with automatic restart on crash.
+- `uploader.py` -- Watches the output directory for new .ts/.m3u8 files and uploads them to S3 with retry.
+- `health.py` -- HTTP health endpoint at :8090/health reporting ffmpeg status.
+
+## Development
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pytest                           # unit tests only
+pytest -m integration            # integration tests (requires ffmpeg)
+```
+
+## Testing
+
+- Unit tests run by default (`pytest`). They use mocks for ffmpeg and S3.
+- Integration tests are marked with `@pytest.mark.integration` and require ffmpeg installed locally. They use moto for S3.
+- Code style: black + ruff, 100 char line length.
+
+## Environment Variables
+
+| Variable | Default | Required | Description |
+|----------|---------|----------|-------------|
+| `IBIBLIO_STREAM_URL` | `https://audio-mp3.ibiblio.org/wxyc.mp3` | No | Source MP3 stream |
+| `S3_BUCKET` | `wxyc-hls` | No | Target S3 bucket |
+| `S3_PREFIX` | `live` | No | S3 key prefix |
+| `AWS_REGION` | `us-east-1` | No | AWS region |
+| `AWS_ACCESS_KEY_ID` | -- | Yes | AWS credentials |
+| `AWS_SECRET_ACCESS_KEY` | -- | Yes | AWS credentials |
+| `HLS_SEGMENT_DURATION` | `6` | No | Segment length in seconds |
+| `HLS_LIST_SIZE` | `600` | No | Max segments in playlist |
+| `HEALTH_PORT` | `8090` | No | Health endpoint port |
+
+## Docker
+
+```bash
+docker build -t hls-ingest .
+docker run -e AWS_ACCESS_KEY_ID=... -e AWS_SECRET_ACCESS_KEY=... hls-ingest
+```

--- a/hls-ingest/Dockerfile
+++ b/hls-ingest/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY *.py ./
+
+EXPOSE 8090
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8090/health')"
+
+CMD ["python", "main.py"]

--- a/hls-ingest/README.md
+++ b/hls-ingest/README.md
@@ -1,0 +1,60 @@
+# hls-ingest
+
+HLS ingest service for WXYC 89.3 FM. Captures the ibiblio MP3 stream, transcodes it into HLS (AAC) segments via ffmpeg, and continuously uploads them to S3 for browser-based time-shifted playback.
+
+## How It Works
+
+1. **ffmpeg** connects to the WXYC ibiblio MP3 stream and produces AAC-encoded HLS segments (6 seconds each by default) with a sliding window playlist.
+2. A **watchdog** file observer detects new `.ts` segments and `.m3u8` playlist updates in the output directory.
+3. The **S3 uploader** pushes each file to the configured bucket with the correct `Content-Type` headers, retrying with exponential backoff on failure.
+4. If ffmpeg crashes or the stream disconnects, the process supervisor automatically restarts it after a brief cooldown.
+5. A **/health** HTTP endpoint on port 8090 reports whether ffmpeg is alive, suitable for container health checks.
+
+## Quick Start
+
+```bash
+# Set up
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+
+# Run tests
+pytest
+
+# Run the service (requires AWS credentials)
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+python main.py
+```
+
+## Docker
+
+```bash
+docker build -t hls-ingest .
+docker run \
+  -e AWS_ACCESS_KEY_ID=... \
+  -e AWS_SECRET_ACCESS_KEY=... \
+  -p 8090:8090 \
+  hls-ingest
+```
+
+## AWS Provisioning
+
+The `scripts/provision-aws.sh` script creates the S3 bucket with lifecycle rules, CORS, and a public read policy:
+
+```bash
+./scripts/provision-aws.sh [bucket-name] [region]
+```
+
+## Configuration
+
+All configuration is via environment variables. See `CLAUDE.md` for the full table.
+
+## Testing
+
+Unit tests run by default. Integration tests (requiring ffmpeg and using moto for S3) are marked with `@pytest.mark.integration`:
+
+```bash
+pytest                    # unit tests
+pytest -m integration     # integration tests
+```

--- a/hls-ingest/config.py
+++ b/hls-ingest/config.py
@@ -1,0 +1,74 @@
+"""Environment variable configuration for the HLS ingest service."""
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Config:
+    """Immutable configuration loaded from environment variables."""
+
+    stream_url: str
+    s3_bucket: str
+    s3_prefix: str
+    aws_region: str
+    aws_access_key_id: str
+    aws_secret_access_key: str
+    hls_segment_duration: int
+    hls_list_size: int
+    health_port: int
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        """Load configuration from environment variables.
+
+        Required:
+            AWS_ACCESS_KEY_ID: AWS access key for S3 uploads.
+            AWS_SECRET_ACCESS_KEY: AWS secret key for S3 uploads.
+
+        Optional (with defaults):
+            IBIBLIO_STREAM_URL: Source MP3 stream URL (default: https://audio-mp3.ibiblio.org/wxyc.mp3).
+            S3_BUCKET: Target S3 bucket name (default: wxyc-hls).
+            S3_PREFIX: Key prefix for uploaded objects (default: live).
+            AWS_REGION: AWS region (default: us-east-1).
+            HLS_SEGMENT_DURATION: Segment duration in seconds (default: 6).
+            HLS_LIST_SIZE: Maximum number of segments in the playlist (default: 600).
+            HEALTH_PORT: Port for the health HTTP endpoint (default: 8090).
+        """
+        raw_segment_duration = os.environ.get("HLS_SEGMENT_DURATION", "6")
+        raw_list_size = os.environ.get("HLS_LIST_SIZE", "600")
+        raw_health_port = os.environ.get("HEALTH_PORT", "8090")
+
+        segment_duration = _parse_positive_int(raw_segment_duration, "HLS_SEGMENT_DURATION")
+        list_size = _parse_positive_int(raw_list_size, "HLS_LIST_SIZE")
+        health_port = _parse_positive_int(raw_health_port, "HEALTH_PORT")
+
+        aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID", "")
+        aws_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+        if not aws_access_key_id or not aws_secret_access_key:
+            raise ValueError("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required")
+
+        return cls(
+            stream_url=os.environ.get(
+                "IBIBLIO_STREAM_URL", "https://audio-mp3.ibiblio.org/wxyc.mp3"
+            ),
+            s3_bucket=os.environ.get("S3_BUCKET", "wxyc-hls"),
+            s3_prefix=os.environ.get("S3_PREFIX", "live"),
+            aws_region=os.environ.get("AWS_REGION", "us-east-1"),
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            hls_segment_duration=segment_duration,
+            hls_list_size=list_size,
+            health_port=health_port,
+        )
+
+
+def _parse_positive_int(value: str, name: str) -> int:
+    """Parse a string as a positive integer, raising ValueError on failure."""
+    try:
+        parsed = int(value)
+    except ValueError:
+        raise ValueError(f"{name} must be an integer, got: {value!r}")
+    if parsed <= 0:
+        raise ValueError(f"{name} must be positive, got: {parsed}")
+    return parsed

--- a/hls-ingest/conftest.py
+++ b/hls-ingest/conftest.py
@@ -1,0 +1,57 @@
+"""Shared pytest fixtures for the HLS ingest service tests."""
+
+import os
+import tempfile
+
+import pytest
+
+from config import Config
+
+
+@pytest.fixture
+def tmp_output_dir(tmp_path):
+    """Provide a temporary directory for HLS output files."""
+    output = tmp_path / "hls-output"
+    output.mkdir()
+    return str(output)
+
+
+@pytest.fixture
+def sample_config():
+    """Provide a Config instance with test defaults."""
+    return Config(
+        stream_url="https://audio-mp3.ibiblio.org/wxyc.mp3",
+        s3_bucket="test-bucket",
+        s3_prefix="live",
+        aws_region="us-east-1",
+        aws_access_key_id="AKIAIOSFODNN7EXAMPLE",
+        aws_secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        hls_segment_duration=6,
+        hls_list_size=600,
+        health_port=8090,
+    )
+
+
+@pytest.fixture
+def sample_ts_file(tmp_output_dir):
+    """Create a sample .ts segment file in the output directory."""
+    path = os.path.join(tmp_output_dir, "seg_00001.ts")
+    with open(path, "wb") as f:
+        f.write(b"\x00" * 1024)
+    return path
+
+
+@pytest.fixture
+def sample_m3u8_file(tmp_output_dir):
+    """Create a sample .m3u8 playlist file in the output directory."""
+    path = os.path.join(tmp_output_dir, "live.m3u8")
+    with open(path, "w") as f:
+        f.write("#EXTM3U\n#EXT-X-VERSION:3\n#EXTINF:6.0,\nseg_00001.ts\n")
+    return path
+
+
+@pytest.fixture
+def env_with_aws(monkeypatch):
+    """Set minimal required environment variables for Config.from_env()."""
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")

--- a/hls-ingest/health.py
+++ b/hls-ingest/health.py
@@ -1,0 +1,50 @@
+"""HTTP health endpoint for the HLS ingest service."""
+
+import json
+import logging
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+def create_health_app(is_healthy: callable) -> web.Application:
+    """Create an aiohttp application with a /health endpoint.
+
+    Args:
+        is_healthy: Callable that returns True if the service is healthy.
+            Typically checks whether ffmpeg is alive.
+
+    Returns:
+        An aiohttp web.Application ready to be run.
+    """
+    app = web.Application()
+
+    async def health_handler(request: web.Request) -> web.Response:
+        healthy = is_healthy()
+        status_code = 200 if healthy else 503
+        body = json.dumps({"status": "ok" if healthy else "degraded", "ffmpeg": healthy})
+        return web.Response(
+            status=status_code, text=body, content_type="application/json"
+        )
+
+    app.router.add_get("/health", health_handler)
+    return app
+
+
+async def run_health_server(port: int, is_healthy: callable) -> web.AppRunner:
+    """Start the health endpoint HTTP server.
+
+    Args:
+        port: TCP port to listen on.
+        is_healthy: Callable returning current health status.
+
+    Returns:
+        The running AppRunner (caller is responsible for cleanup).
+    """
+    app = create_health_app(is_healthy)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "0.0.0.0", port)
+    await site.start()
+    logger.info("Health endpoint listening on :%d/health", port)
+    return runner

--- a/hls-ingest/ingest.py
+++ b/hls-ingest/ingest.py
@@ -1,0 +1,135 @@
+"""ffmpeg subprocess management for HLS segmentation of the WXYC ibiblio stream."""
+
+import logging
+import os
+import subprocess
+import time
+
+from config import Config
+
+logger = logging.getLogger(__name__)
+
+# Minimum seconds between restart attempts to avoid tight restart loops.
+MIN_RESTART_INTERVAL = 5.0
+
+
+def build_ffmpeg_args(config: Config, output_dir: str) -> list[str]:
+    """Build the ffmpeg command-line arguments for HLS segmentation.
+
+    Connects to the ibiblio MP3 stream and outputs AAC-encoded HLS segments
+    with the configured segment duration and playlist window size.
+
+    Args:
+        config: Service configuration.
+        output_dir: Directory where .ts segments and .m3u8 playlist are written.
+
+    Returns:
+        List of command-line arguments suitable for subprocess.Popen.
+    """
+    playlist_path = os.path.join(output_dir, "live.m3u8")
+    segment_pattern = os.path.join(output_dir, "seg_%05d.ts")
+
+    return [
+        "ffmpeg",
+        "-reconnect",
+        "1",
+        "-reconnect_streamed",
+        "1",
+        "-reconnect_delay_max",
+        "30",
+        "-i",
+        config.stream_url,
+        "-c:a",
+        "aac",
+        "-b:a",
+        "128k",
+        "-ac",
+        "2",
+        "-f",
+        "hls",
+        "-hls_time",
+        str(config.hls_segment_duration),
+        "-hls_list_size",
+        str(config.hls_list_size),
+        "-hls_flags",
+        "delete_segments+append_list",
+        "-hls_segment_filename",
+        segment_pattern,
+        playlist_path,
+    ]
+
+
+class IngestProcess:
+    """Manages the ffmpeg subprocess lifecycle with automatic restart on failure.
+
+    Attributes:
+        config: Service configuration.
+        output_dir: Directory for HLS output files.
+        process: The currently running ffmpeg subprocess, or None.
+        running: Whether the ingest loop should continue.
+    """
+
+    def __init__(self, config: Config, output_dir: str) -> None:
+        self.config = config
+        self.output_dir = output_dir
+        self.process: subprocess.Popen | None = None
+        self.running: bool = False
+        self._last_start_time: float = 0.0
+
+    def start(self) -> None:
+        """Launch the ffmpeg process."""
+        os.makedirs(self.output_dir, exist_ok=True)
+        args = build_ffmpeg_args(self.config, self.output_dir)
+        logger.info("Starting ffmpeg: %s", " ".join(args))
+        self.process = subprocess.Popen(
+            args,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+        )
+        self._last_start_time = time.monotonic()
+
+    def stop(self) -> None:
+        """Gracefully stop the ffmpeg process."""
+        self.running = False
+        if self.process and self.process.poll() is None:
+            logger.info("Stopping ffmpeg (pid %d)", self.process.pid)
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                logger.warning("ffmpeg did not exit in time, killing")
+                self.process.kill()
+                self.process.wait()
+        self.process = None
+
+    def is_alive(self) -> bool:
+        """Check whether the ffmpeg process is currently running."""
+        return self.process is not None and self.process.poll() is None
+
+    def run_forever(self) -> None:
+        """Run the ffmpeg process in a loop, restarting on crash.
+
+        Blocks until stop() is called from another thread. Enforces a minimum
+        restart interval to avoid tight loops when ffmpeg fails immediately.
+        """
+        self.running = True
+        while self.running:
+            self.start()
+            if self.process is None:
+                break
+
+            self.process.wait()
+            exit_code = self.process.returncode
+            logger.warning("ffmpeg exited with code %d", exit_code)
+
+            if not self.running:
+                break
+
+            # Enforce minimum restart interval
+            elapsed = time.monotonic() - self._last_start_time
+            if elapsed < MIN_RESTART_INTERVAL:
+                delay = MIN_RESTART_INTERVAL - elapsed
+                logger.info("Waiting %.1fs before restart", delay)
+                time.sleep(delay)
+
+            logger.info("Restarting ffmpeg...")

--- a/hls-ingest/main.py
+++ b/hls-ingest/main.py
@@ -1,0 +1,90 @@
+"""Entry point for the HLS ingest service.
+
+Orchestrates ffmpeg ingest, S3 upload, and health endpoint.
+"""
+
+import asyncio
+import logging
+import signal
+import sys
+import tempfile
+import threading
+
+import boto3
+
+from config import Config
+from health import run_health_server
+from ingest import IngestProcess
+from uploader import UploadWorker
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    stream=sys.stdout,
+)
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    """Run the HLS ingest service."""
+    try:
+        config = Config.from_env()
+    except ValueError as e:
+        logger.error("Configuration error: %s", e)
+        sys.exit(1)
+
+    output_dir = tempfile.mkdtemp(prefix="hls-ingest-")
+    logger.info("HLS output directory: %s", output_dir)
+
+    # Set up S3 client
+    s3_client = boto3.client(
+        "s3",
+        region_name=config.aws_region,
+        aws_access_key_id=config.aws_access_key_id,
+        aws_secret_access_key=config.aws_secret_access_key,
+    )
+
+    # Set up components
+    ingest = IngestProcess(config, output_dir)
+    uploader = UploadWorker(s3_client, config.s3_bucket, config.s3_prefix, output_dir)
+
+    # Graceful shutdown handler
+    def handle_signal(signum, frame):
+        logger.info("Received signal %d, shutting down...", signum)
+        ingest.stop()
+        uploader.stop()
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    # Start upload worker
+    uploader.start()
+
+    # Start health endpoint in async thread
+    loop = asyncio.new_event_loop()
+
+    async def start_health():
+        return await run_health_server(config.health_port, ingest.is_alive)
+
+    health_runner = None
+
+    def run_health_loop():
+        nonlocal health_runner
+        asyncio.set_event_loop(loop)
+        health_runner = loop.run_until_complete(start_health())
+        loop.run_forever()
+
+    health_thread = threading.Thread(target=run_health_loop, daemon=True)
+    health_thread.start()
+
+    # Run ffmpeg ingest (blocks until stopped)
+    try:
+        ingest.run_forever()
+    finally:
+        uploader.stop()
+        loop.call_soon_threadsafe(loop.stop)
+        logger.info("Shutdown complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/hls-ingest/pyproject.toml
+++ b/hls-ingest/pyproject.toml
@@ -1,0 +1,14 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+markers = [
+    "integration: tests requiring external services (ffmpeg, moto S3)",
+]
+addopts = "-m 'not integration'"
+asyncio_mode = "auto"
+
+[tool.black]
+line-length = 100
+
+[tool.ruff]
+line-length = 100

--- a/hls-ingest/requirements.txt
+++ b/hls-ingest/requirements.txt
@@ -1,0 +1,8 @@
+boto3>=1.34,<2
+watchdog>=4.0,<5
+aiohttp>=3.9,<4
+pytest>=8.0,<9
+pytest-asyncio>=0.23,<1
+moto[s3]>=5.0,<6
+black>=24.0
+ruff>=0.3

--- a/hls-ingest/scripts/provision-aws.sh
+++ b/hls-ingest/scripts/provision-aws.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+#
+# Provision AWS resources for the HLS ingest service.
+#
+# Creates the S3 bucket with a lifecycle rule to expire old segments,
+# and configures CORS for browser-based HLS playback.
+#
+# Usage:
+#   ./scripts/provision-aws.sh [bucket-name] [region]
+#
+# Defaults:
+#   bucket-name: wxyc-hls
+#   region: us-east-1
+
+set -euo pipefail
+
+BUCKET="${1:-wxyc-hls}"
+REGION="${2:-us-east-1}"
+
+echo "Provisioning S3 bucket: $BUCKET in $REGION"
+
+# Create bucket
+if aws s3api head-bucket --bucket "$BUCKET" 2>/dev/null; then
+    echo "Bucket $BUCKET already exists"
+else
+    if [ "$REGION" = "us-east-1" ]; then
+        aws s3api create-bucket --bucket "$BUCKET" --region "$REGION"
+    else
+        aws s3api create-bucket --bucket "$BUCKET" --region "$REGION" \
+            --create-bucket-configuration LocationConstraint="$REGION"
+    fi
+    echo "Created bucket $BUCKET"
+fi
+
+# Enable versioning (protects against accidental overwrites of the playlist)
+aws s3api put-bucket-versioning --bucket "$BUCKET" \
+    --versioning-configuration Status=Enabled
+echo "Enabled versioning"
+
+# Lifecycle rule: expire segments older than 2 days.
+# The sliding window is maintained by ffmpeg's delete_segments flag, but this
+# acts as a safety net for any segments that slip through.
+aws s3api put-bucket-lifecycle-configuration --bucket "$BUCKET" \
+    --lifecycle-configuration '{
+        "Rules": [
+            {
+                "ID": "expire-old-segments",
+                "Status": "Enabled",
+                "Filter": {
+                    "Prefix": "live/"
+                },
+                "Expiration": {
+                    "Days": 2
+                }
+            }
+        ]
+    }'
+echo "Configured lifecycle rule (expire after 2 days)"
+
+# CORS configuration for browser-based HLS playback
+aws s3api put-bucket-cors --bucket "$BUCKET" \
+    --cors-configuration '{
+        "CORSRules": [
+            {
+                "AllowedOrigins": ["*"],
+                "AllowedMethods": ["GET", "HEAD"],
+                "AllowedHeaders": ["*"],
+                "MaxAgeSeconds": 3600
+            }
+        ]
+    }'
+echo "Configured CORS for HLS playback"
+
+# Bucket policy: allow public read for the live/ prefix
+aws s3api put-bucket-policy --bucket "$BUCKET" \
+    --policy "{
+        \"Version\": \"2012-10-17\",
+        \"Statement\": [
+            {
+                \"Sid\": \"PublicReadHLS\",
+                \"Effect\": \"Allow\",
+                \"Principal\": \"*\",
+                \"Action\": \"s3:GetObject\",
+                \"Resource\": \"arn:aws:s3:::$BUCKET/live/*\"
+            }
+        ]
+    }"
+echo "Configured public read policy for live/ prefix"
+
+echo ""
+echo "Provisioning complete. Stream URL will be:"
+echo "  https://$BUCKET.s3.$REGION.amazonaws.com/live/live.m3u8"

--- a/hls-ingest/tests/test_config.py
+++ b/hls-ingest/tests/test_config.py
@@ -1,0 +1,85 @@
+"""Tests for environment variable configuration parsing."""
+
+import pytest
+
+from config import Config, _parse_positive_int
+
+
+class TestParsePositiveInt:
+    """Tests for the _parse_positive_int helper."""
+
+    def test_valid_integer(self):
+        assert _parse_positive_int("42", "TEST") == 42
+
+    def test_one_is_valid(self):
+        assert _parse_positive_int("1", "TEST") == 1
+
+    @pytest.mark.parametrize("value", ["0", "-1", "-100"])
+    def test_non_positive_raises(self, value):
+        with pytest.raises(ValueError, match="must be positive"):
+            _parse_positive_int(value, "TEST")
+
+    @pytest.mark.parametrize("value", ["abc", "3.14", "", " "])
+    def test_non_integer_raises(self, value):
+        with pytest.raises(ValueError, match="must be an integer"):
+            _parse_positive_int(value, "TEST")
+
+
+class TestConfigFromEnv:
+    """Tests for Config.from_env()."""
+
+    def test_defaults_with_required_keys(self, env_with_aws):
+        config = Config.from_env()
+        assert config.stream_url == "https://audio-mp3.ibiblio.org/wxyc.mp3"
+        assert config.s3_bucket == "wxyc-hls"
+        assert config.s3_prefix == "live"
+        assert config.aws_region == "us-east-1"
+        assert config.hls_segment_duration == 6
+        assert config.hls_list_size == 600
+        assert config.health_port == 8090
+
+    def test_missing_aws_key_raises(self, monkeypatch):
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        with pytest.raises(ValueError, match="AWS_ACCESS_KEY_ID"):
+            Config.from_env()
+
+    def test_missing_secret_key_raises(self, monkeypatch):
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        with pytest.raises(ValueError, match="AWS_ACCESS_KEY_ID"):
+            Config.from_env()
+
+    def test_custom_env_values(self, monkeypatch):
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+        monkeypatch.setenv("IBIBLIO_STREAM_URL", "http://localhost:8000/stream.mp3")
+        monkeypatch.setenv("S3_BUCKET", "my-bucket")
+        monkeypatch.setenv("S3_PREFIX", "staging")
+        monkeypatch.setenv("AWS_REGION", "eu-west-1")
+        monkeypatch.setenv("HLS_SEGMENT_DURATION", "10")
+        monkeypatch.setenv("HLS_LIST_SIZE", "300")
+        monkeypatch.setenv("HEALTH_PORT", "9090")
+
+        config = Config.from_env()
+        assert config.stream_url == "http://localhost:8000/stream.mp3"
+        assert config.s3_bucket == "my-bucket"
+        assert config.s3_prefix == "staging"
+        assert config.aws_region == "eu-west-1"
+        assert config.hls_segment_duration == 10
+        assert config.hls_list_size == 300
+        assert config.health_port == 9090
+
+    def test_invalid_segment_duration_raises(self, env_with_aws, monkeypatch):
+        monkeypatch.setenv("HLS_SEGMENT_DURATION", "not-a-number")
+        with pytest.raises(ValueError, match="HLS_SEGMENT_DURATION"):
+            Config.from_env()
+
+    def test_zero_list_size_raises(self, env_with_aws, monkeypatch):
+        monkeypatch.setenv("HLS_LIST_SIZE", "0")
+        with pytest.raises(ValueError, match="HLS_LIST_SIZE"):
+            Config.from_env()
+
+    def test_config_is_immutable(self, sample_config):
+        with pytest.raises(AttributeError):
+            sample_config.s3_bucket = "other-bucket"

--- a/hls-ingest/tests/test_health.py
+++ b/hls-ingest/tests/test_health.py
@@ -1,0 +1,57 @@
+"""Tests for the health endpoint under various states."""
+
+import json
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase, TestClient, TestServer
+
+from health import create_health_app
+
+pytest_plugins = ["pytest_asyncio"]
+
+
+@pytest.fixture
+def healthy_app():
+    """Create a health app that reports healthy status."""
+    return create_health_app(is_healthy=lambda: True)
+
+
+@pytest.fixture
+def unhealthy_app():
+    """Create a health app that reports unhealthy status."""
+    return create_health_app(is_healthy=lambda: False)
+
+
+@pytest.mark.asyncio
+async def test_health_returns_200_when_healthy(healthy_app, aiohttp_client):
+    client = await aiohttp_client(healthy_app)
+    resp = await client.get("/health")
+    assert resp.status == 200
+    body = await resp.json()
+    assert body["status"] == "ok"
+    assert body["ffmpeg"] is True
+
+
+@pytest.mark.asyncio
+async def test_health_returns_503_when_unhealthy(unhealthy_app, aiohttp_client):
+    client = await aiohttp_client(unhealthy_app)
+    resp = await client.get("/health")
+    assert resp.status == 503
+    body = await resp.json()
+    assert body["status"] == "degraded"
+    assert body["ffmpeg"] is False
+
+
+@pytest.mark.asyncio
+async def test_health_content_type(healthy_app, aiohttp_client):
+    client = await aiohttp_client(healthy_app)
+    resp = await client.get("/health")
+    assert "application/json" in resp.headers["Content-Type"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_route_returns_404(healthy_app, aiohttp_client):
+    client = await aiohttp_client(healthy_app)
+    resp = await client.get("/nonexistent")
+    assert resp.status == 404

--- a/hls-ingest/tests/test_ingest.py
+++ b/hls-ingest/tests/test_ingest.py
@@ -1,0 +1,143 @@
+"""Tests for ffmpeg process lifecycle: start, crash-restart, reconnect."""
+
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from config import Config
+from ingest import IngestProcess, build_ffmpeg_args
+
+
+class TestBuildFfmpegArgs:
+    """Tests for the ffmpeg argument builder."""
+
+    def test_contains_input_url(self, sample_config, tmp_output_dir):
+        args = build_ffmpeg_args(sample_config, tmp_output_dir)
+        assert sample_config.stream_url in args
+
+    def test_contains_aac_codec(self, sample_config, tmp_output_dir):
+        args = build_ffmpeg_args(sample_config, tmp_output_dir)
+        idx = args.index("-c:a")
+        assert args[idx + 1] == "aac"
+
+    def test_contains_hls_time(self, sample_config, tmp_output_dir):
+        args = build_ffmpeg_args(sample_config, tmp_output_dir)
+        idx = args.index("-hls_time")
+        assert args[idx + 1] == "6"
+
+    def test_contains_hls_list_size(self, sample_config, tmp_output_dir):
+        args = build_ffmpeg_args(sample_config, tmp_output_dir)
+        idx = args.index("-hls_list_size")
+        assert args[idx + 1] == "600"
+
+    def test_output_path_is_in_output_dir(self, sample_config, tmp_output_dir):
+        args = build_ffmpeg_args(sample_config, tmp_output_dir)
+        playlist_path = args[-1]
+        assert playlist_path == os.path.join(tmp_output_dir, "live.m3u8")
+
+    def test_segment_pattern_is_in_output_dir(self, sample_config, tmp_output_dir):
+        args = build_ffmpeg_args(sample_config, tmp_output_dir)
+        idx = args.index("-hls_segment_filename")
+        segment_pattern = args[idx + 1]
+        assert segment_pattern.startswith(tmp_output_dir)
+        assert "seg_" in segment_pattern
+
+    def test_reconnect_flags_present(self, sample_config, tmp_output_dir):
+        args = build_ffmpeg_args(sample_config, tmp_output_dir)
+        assert "-reconnect" in args
+        assert "-reconnect_streamed" in args
+
+    def test_hls_flags_include_delete_segments(self, sample_config, tmp_output_dir):
+        args = build_ffmpeg_args(sample_config, tmp_output_dir)
+        idx = args.index("-hls_flags")
+        assert "delete_segments" in args[idx + 1]
+
+
+class TestIngestProcess:
+    """Tests for the IngestProcess class."""
+
+    @patch("ingest.subprocess.Popen")
+    def test_start_launches_ffmpeg(self, mock_popen, sample_config, tmp_output_dir):
+        proc = IngestProcess(sample_config, tmp_output_dir)
+        mock_popen.return_value = MagicMock()
+        proc.start()
+        mock_popen.assert_called_once()
+        assert proc.process is not None
+
+    @patch("ingest.subprocess.Popen")
+    def test_stop_terminates_process(self, mock_popen, sample_config, tmp_output_dir):
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        proc = IngestProcess(sample_config, tmp_output_dir)
+        proc.start()
+        proc.stop()
+
+        mock_process.terminate.assert_called_once()
+        assert proc.running is False
+        assert proc.process is None
+
+    @patch("ingest.subprocess.Popen")
+    def test_stop_kills_if_terminate_times_out(self, mock_popen, sample_config, tmp_output_dir):
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.wait.side_effect = [subprocess.TimeoutExpired("ffmpeg", 10), None]
+        mock_popen.return_value = mock_process
+
+        proc = IngestProcess(sample_config, tmp_output_dir)
+        proc.start()
+        proc.stop()
+
+        mock_process.kill.assert_called_once()
+
+    @patch("ingest.subprocess.Popen")
+    def test_is_alive_when_running(self, mock_popen, sample_config, tmp_output_dir):
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        proc = IngestProcess(sample_config, tmp_output_dir)
+        proc.start()
+        assert proc.is_alive() is True
+
+    @patch("ingest.subprocess.Popen")
+    def test_is_alive_false_when_exited(self, mock_popen, sample_config, tmp_output_dir):
+        mock_process = MagicMock()
+        mock_process.poll.return_value = 1
+        mock_popen.return_value = mock_process
+
+        proc = IngestProcess(sample_config, tmp_output_dir)
+        proc.start()
+        assert proc.is_alive() is False
+
+    def test_is_alive_false_before_start(self, sample_config, tmp_output_dir):
+        proc = IngestProcess(sample_config, tmp_output_dir)
+        assert proc.is_alive() is False
+
+    @patch("ingest.subprocess.Popen")
+    @patch("ingest.time.sleep")
+    def test_run_forever_restarts_on_crash(self, mock_sleep, mock_popen, sample_config, tmp_output_dir):
+        """Verify that run_forever restarts ffmpeg after a crash."""
+        call_count = 0
+
+        def create_mock_process(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            mock_proc = MagicMock()
+            mock_proc.returncode = 1
+            # On first call, simulate immediate exit. On second call, stop the loop.
+            if call_count >= 2:
+                # Stop the loop after second launch
+                proc.running = False
+            return mock_proc
+
+        mock_popen.side_effect = create_mock_process
+
+        proc = IngestProcess(sample_config, tmp_output_dir)
+        proc.run_forever()
+
+        assert call_count == 2
+        assert mock_popen.call_count == 2

--- a/hls-ingest/tests/test_integration.py
+++ b/hls-ingest/tests/test_integration.py
@@ -1,0 +1,81 @@
+"""Integration tests: real ffmpeg + mocked S3 via moto.
+
+These tests require ffmpeg to be installed and are marked with
+@pytest.mark.integration so they don't run by default.
+"""
+
+import os
+import time
+
+import boto3
+import pytest
+from moto import mock_aws
+
+from config import Config
+from ingest import IngestProcess, build_ffmpeg_args
+from uploader import UploadWorker, upload_with_retry
+
+
+@pytest.fixture
+def moto_s3():
+    """Provide a mocked S3 client via moto."""
+    with mock_aws():
+        client = boto3.client("s3", region_name="us-east-1")
+        client.create_bucket(Bucket="test-bucket")
+        yield client
+
+
+@pytest.fixture
+def integration_config():
+    """Config suitable for integration tests."""
+    return Config(
+        stream_url="https://audio-mp3.ibiblio.org/wxyc.mp3",
+        s3_bucket="test-bucket",
+        s3_prefix="live",
+        aws_region="us-east-1",
+        aws_access_key_id="testing",
+        aws_secret_access_key="testing",
+        hls_segment_duration=2,
+        hls_list_size=5,
+        health_port=18090,
+    )
+
+
+@pytest.mark.integration
+def test_upload_to_mocked_s3(moto_s3, tmp_path):
+    """Verify that upload_with_retry sends a file to the mocked S3 bucket."""
+    test_file = tmp_path / "seg_00001.ts"
+    test_file.write_bytes(b"\x00" * 512)
+
+    result = upload_with_retry(moto_s3, str(test_file), "test-bucket", "live/seg_00001.ts")
+    assert result is True
+
+    obj = moto_s3.get_object(Bucket="test-bucket", Key="live/seg_00001.ts")
+    assert obj["ContentLength"] == 512
+    assert obj["ContentType"] == "video/MP2T"
+
+
+@pytest.mark.integration
+def test_upload_m3u8_content_type(moto_s3, tmp_path):
+    """Verify that .m3u8 files get the correct content type in S3."""
+    playlist = tmp_path / "live.m3u8"
+    playlist.write_text("#EXTM3U\n#EXT-X-VERSION:3\n")
+
+    upload_with_retry(moto_s3, str(playlist), "test-bucket", "live/live.m3u8")
+
+    obj = moto_s3.get_object(Bucket="test-bucket", Key="live/live.m3u8")
+    assert obj["ContentType"] == "application/vnd.apple.mpegurl"
+
+
+@pytest.mark.integration
+def test_ffmpeg_args_are_well_formed(integration_config, tmp_path):
+    """Verify ffmpeg args form a valid command structure."""
+    output_dir = str(tmp_path / "hls")
+    os.makedirs(output_dir)
+    args = build_ffmpeg_args(integration_config, output_dir)
+
+    assert args[0] == "ffmpeg"
+    assert "-i" in args
+    assert "-f" in args
+    idx = args.index("-f")
+    assert args[idx + 1] == "hls"

--- a/hls-ingest/tests/test_uploader.py
+++ b/hls-ingest/tests/test_uploader.py
@@ -1,0 +1,162 @@
+"""Tests for S3 uploads: segment detection, retry logic, content types."""
+
+import os
+import time
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from uploader import (
+    HLSUploadHandler,
+    content_type_for_file,
+    s3_key_for_file,
+    upload_with_retry,
+)
+
+
+class TestS3KeyForFile:
+    """Tests for S3 key construction."""
+
+    def test_with_prefix(self):
+        assert s3_key_for_file("live", "seg_00001.ts") == "live/seg_00001.ts"
+
+    def test_with_empty_prefix(self):
+        assert s3_key_for_file("", "seg_00001.ts") == "seg_00001.ts"
+
+    def test_playlist_key(self):
+        assert s3_key_for_file("live", "live.m3u8") == "live/live.m3u8"
+
+
+class TestContentTypeForFile:
+    """Tests for content type detection."""
+
+    def test_ts_file(self):
+        assert content_type_for_file("seg_00001.ts") == "video/MP2T"
+
+    def test_m3u8_file(self):
+        assert content_type_for_file("live.m3u8") == "application/vnd.apple.mpegurl"
+
+    def test_unknown_extension(self):
+        assert content_type_for_file("readme.txt") is None
+
+    def test_no_extension(self):
+        assert content_type_for_file("Makefile") is None
+
+
+class TestUploadWithRetry:
+    """Tests for the upload retry mechanism."""
+
+    @patch("uploader.time.sleep")
+    def test_successful_upload_on_first_try(self, mock_sleep):
+        mock_client = MagicMock()
+        result = upload_with_retry(mock_client, "/tmp/seg.ts", "bucket", "live/seg.ts")
+        assert result is True
+        mock_client.upload_file.assert_called_once()
+        mock_sleep.assert_not_called()
+
+    @patch("uploader.time.sleep")
+    def test_retry_on_failure_then_succeed(self, mock_sleep):
+        mock_client = MagicMock()
+        mock_client.upload_file.side_effect = [Exception("network error"), None]
+
+        result = upload_with_retry(mock_client, "/tmp/seg.ts", "bucket", "live/seg.ts")
+        assert result is True
+        assert mock_client.upload_file.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("uploader.time.sleep")
+    def test_all_retries_exhausted(self, mock_sleep):
+        mock_client = MagicMock()
+        mock_client.upload_file.side_effect = Exception("persistent error")
+
+        result = upload_with_retry(
+            mock_client, "/tmp/seg.ts", "bucket", "live/seg.ts", max_retries=3
+        )
+        assert result is False
+        assert mock_client.upload_file.call_count == 3
+
+    @patch("uploader.time.sleep")
+    def test_exponential_backoff(self, mock_sleep):
+        mock_client = MagicMock()
+        mock_client.upload_file.side_effect = Exception("fail")
+
+        upload_with_retry(
+            mock_client, "/tmp/seg.ts", "bucket", "live/seg.ts", max_retries=3, base_backoff=1.0
+        )
+
+        assert mock_sleep.call_args_list == [call(1.0), call(2.0), call(4.0)]
+
+    @patch("uploader.time.sleep")
+    def test_ts_file_gets_content_type(self, mock_sleep):
+        mock_client = MagicMock()
+        upload_with_retry(mock_client, "/tmp/seg_00001.ts", "bucket", "live/seg_00001.ts")
+
+        _, kwargs = mock_client.upload_file.call_args
+        assert kwargs["ExtraArgs"]["ContentType"] == "video/MP2T"
+
+    @patch("uploader.time.sleep")
+    def test_m3u8_file_gets_content_type(self, mock_sleep):
+        mock_client = MagicMock()
+        upload_with_retry(mock_client, "/tmp/live.m3u8", "bucket", "live/live.m3u8")
+
+        _, kwargs = mock_client.upload_file.call_args
+        assert kwargs["ExtraArgs"]["ContentType"] == "application/vnd.apple.mpegurl"
+
+    @patch("uploader.time.sleep")
+    def test_unknown_file_no_extra_args(self, mock_sleep):
+        mock_client = MagicMock()
+        upload_with_retry(mock_client, "/tmp/readme.txt", "bucket", "live/readme.txt")
+
+        _, kwargs = mock_client.upload_file.call_args
+        assert kwargs["ExtraArgs"] is None
+
+
+class TestHLSUploadHandler:
+    """Tests for the watchdog event handler."""
+
+    def test_handles_ts_file_creation(self, tmp_output_dir):
+        mock_client = MagicMock()
+        handler = HLSUploadHandler(mock_client, "bucket", "live")
+
+        ts_path = os.path.join(tmp_output_dir, "seg_00001.ts")
+        with open(ts_path, "wb") as f:
+            f.write(b"\x00" * 100)
+
+        from watchdog.events import FileCreatedEvent
+
+        event = FileCreatedEvent(ts_path)
+        with patch("uploader.upload_with_retry") as mock_upload:
+            handler.on_created(event)
+            mock_upload.assert_called_once_with(
+                mock_client, ts_path, "bucket", "live/seg_00001.ts"
+            )
+
+    def test_ignores_non_hls_files(self, tmp_output_dir):
+        mock_client = MagicMock()
+        handler = HLSUploadHandler(mock_client, "bucket", "live")
+
+        txt_path = os.path.join(tmp_output_dir, "notes.txt")
+        with open(txt_path, "w") as f:
+            f.write("hello")
+
+        from watchdog.events import FileCreatedEvent
+
+        event = FileCreatedEvent(txt_path)
+        with patch("uploader.upload_with_retry") as mock_upload:
+            handler.on_created(event)
+            mock_upload.assert_not_called()
+
+    def test_handles_m3u8_modification(self, tmp_output_dir):
+        mock_client = MagicMock()
+        handler = HLSUploadHandler(mock_client, "bucket", "live")
+
+        m3u8_path = os.path.join(tmp_output_dir, "live.m3u8")
+        with open(m3u8_path, "w") as f:
+            f.write("#EXTM3U\n")
+
+        from watchdog.events import FileModifiedEvent
+
+        event = FileModifiedEvent(m3u8_path)
+        with patch("uploader.upload_with_retry") as mock_upload:
+            handler.on_modified(event)
+            mock_upload.assert_called_once()

--- a/hls-ingest/uploader.py
+++ b/hls-ingest/uploader.py
@@ -1,0 +1,164 @@
+"""S3 upload worker that watches for new HLS segments and uploads them."""
+
+import logging
+import os
+import time
+from typing import Protocol
+
+from watchdog.events import FileCreatedEvent, FileModifiedEvent, FileSystemEventHandler
+from watchdog.observers import Observer
+
+logger = logging.getLogger(__name__)
+
+# Content type mapping for HLS files.
+CONTENT_TYPES = {
+    ".m3u8": "application/vnd.apple.mpegurl",
+    ".ts": "video/MP2T",
+}
+
+# Retry configuration for S3 uploads.
+MAX_RETRIES = 3
+BASE_BACKOFF = 1.0
+
+
+class S3Client(Protocol):
+    """Protocol for S3 upload operations (satisfied by boto3 S3 client)."""
+
+    def upload_file(
+        self, Filename: str, Bucket: str, Key: str, ExtraArgs: dict | None = None
+    ) -> None: ...
+
+
+def s3_key_for_file(prefix: str, filename: str) -> str:
+    """Build the S3 object key for a given local filename.
+
+    Args:
+        prefix: S3 key prefix (e.g. "live").
+        filename: Base filename (e.g. "seg_00001.ts").
+
+    Returns:
+        Full S3 key (e.g. "live/seg_00001.ts").
+    """
+    return f"{prefix}/{filename}" if prefix else filename
+
+
+def content_type_for_file(filename: str) -> str | None:
+    """Return the appropriate Content-Type for an HLS file, or None if unknown."""
+    _, ext = os.path.splitext(filename)
+    return CONTENT_TYPES.get(ext)
+
+
+def upload_with_retry(
+    s3_client: S3Client,
+    local_path: str,
+    bucket: str,
+    key: str,
+    max_retries: int = MAX_RETRIES,
+    base_backoff: float = BASE_BACKOFF,
+) -> bool:
+    """Upload a file to S3 with exponential backoff retry.
+
+    Args:
+        s3_client: S3 client implementing upload_file.
+        local_path: Path to the local file to upload.
+        bucket: S3 bucket name.
+        key: S3 object key.
+        max_retries: Maximum number of retry attempts.
+        base_backoff: Base delay in seconds for exponential backoff.
+
+    Returns:
+        True if upload succeeded, False if all retries were exhausted.
+    """
+    content_type = content_type_for_file(os.path.basename(local_path))
+    extra_args = {}
+    if content_type:
+        extra_args["ContentType"] = content_type
+
+    for attempt in range(max_retries):
+        try:
+            s3_client.upload_file(
+                Filename=local_path,
+                Bucket=bucket,
+                Key=key,
+                ExtraArgs=extra_args if extra_args else None,
+            )
+            logger.debug("Uploaded %s -> s3://%s/%s", local_path, bucket, key)
+            return True
+        except Exception:
+            delay = base_backoff * (2**attempt)
+            logger.warning(
+                "Upload failed for %s (attempt %d/%d), retrying in %.1fs",
+                local_path,
+                attempt + 1,
+                max_retries,
+                delay,
+                exc_info=True,
+            )
+            time.sleep(delay)
+
+    logger.error("Upload permanently failed for %s after %d attempts", local_path, max_retries)
+    return False
+
+
+class HLSUploadHandler(FileSystemEventHandler):
+    """Watchdog handler that uploads new/modified HLS files to S3.
+
+    Monitors a directory for .ts and .m3u8 file events and uploads them
+    to the configured S3 bucket with appropriate content types.
+    """
+
+    def __init__(self, s3_client: S3Client, bucket: str, prefix: str) -> None:
+        super().__init__()
+        self.s3_client = s3_client
+        self.bucket = bucket
+        self.prefix = prefix
+
+    def on_created(self, event: FileCreatedEvent) -> None:
+        """Handle new file creation events."""
+        if not event.is_directory:
+            self._handle_file(event.src_path)
+
+    def on_modified(self, event: FileModifiedEvent) -> None:
+        """Handle file modification events (for playlist updates)."""
+        if not event.is_directory:
+            self._handle_file(event.src_path)
+
+    def _handle_file(self, path: str) -> None:
+        """Upload a file if it has an HLS-related extension."""
+        filename = os.path.basename(path)
+        _, ext = os.path.splitext(filename)
+        if ext not in CONTENT_TYPES:
+            return
+
+        key = s3_key_for_file(self.prefix, filename)
+        upload_with_retry(self.s3_client, path, self.bucket, key)
+
+
+class UploadWorker:
+    """Watches a directory for new HLS segments and uploads them to S3.
+
+    Uses watchdog's Observer to monitor the filesystem and trigger uploads
+    via HLSUploadHandler.
+
+    Attributes:
+        observer: The watchdog Observer instance.
+        watch_dir: Directory being monitored.
+    """
+
+    def __init__(self, s3_client: S3Client, bucket: str, prefix: str, watch_dir: str) -> None:
+        self.watch_dir = watch_dir
+        self.handler = HLSUploadHandler(s3_client, bucket, prefix)
+        self.observer = Observer()
+
+    def start(self) -> None:
+        """Start watching the directory for new files."""
+        os.makedirs(self.watch_dir, exist_ok=True)
+        self.observer.schedule(self.handler, self.watch_dir, recursive=False)
+        self.observer.start()
+        logger.info("Upload worker watching %s", self.watch_dir)
+
+    def stop(self) -> None:
+        """Stop the directory watcher."""
+        self.observer.stop()
+        self.observer.join(timeout=10)
+        logger.info("Upload worker stopped")


### PR DESCRIPTION
## Summary

- Adds `hls-ingest/`, a Python service that captures the WXYC ibiblio MP3 stream via ffmpeg, segments it into HLS (6-second AAC, 600-segment sliding window), and uploads segments + `.m3u8` playlist to S3
- Includes process supervision (ffmpeg auto-restart), S3 upload retry with exponential backoff, and a health endpoint on :8090
- 52 unit tests covering config parsing, ffmpeg lifecycle, upload retry logic, and health endpoint; 3 integration tests (moto S3)
- Includes Dockerfile and `scripts/provision-aws.sh` for AWS resource setup

## Test plan

- [ ] `cd hls-ingest && python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt && pytest -v`
- [ ] `pytest -m integration` (requires ffmpeg)
- [ ] `docker build -t hls-ingest .` builds successfully
- [ ] Verify existing `record_audio.pl` and `cron_file` are unmodified

Closes #1