### PR TITLE
Fix 8 bugs in hls-ingest service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+    paths: [hls-ingest/**]
+  pull_request:
+    paths: [hls-ingest/**]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: hls-ingest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: hls-ingest/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Format (black)
+        run: black --check --line-length 100 .
+
+      - name: Unit tests
+        run: pytest -v
+
+      - name: Integration tests
+        run: pytest -m integration -v

--- a/hls-ingest/conftest.py
+++ b/hls-ingest/conftest.py
@@ -1,7 +1,6 @@
 """Shared pytest fixtures for the HLS ingest service tests."""
 
 import os
-import tempfile
 
 import pytest
 

--- a/hls-ingest/health.py
+++ b/hls-ingest/health.py
@@ -2,12 +2,13 @@
 
 import json
 import logging
+from collections.abc import Callable
 from aiohttp import web
 
 logger = logging.getLogger(__name__)
 
 
-def create_health_app(is_healthy: callable) -> web.Application:
+def create_health_app(is_healthy: Callable[[], bool]) -> web.Application:
     """Create an aiohttp application with a /health endpoint.
 
     Args:
@@ -23,15 +24,13 @@ def create_health_app(is_healthy: callable) -> web.Application:
         healthy = is_healthy()
         status_code = 200 if healthy else 503
         body = json.dumps({"status": "ok" if healthy else "degraded", "ffmpeg": healthy})
-        return web.Response(
-            status=status_code, text=body, content_type="application/json"
-        )
+        return web.Response(status=status_code, text=body, content_type="application/json")
 
     app.router.add_get("/health", health_handler)
     return app
 
 
-async def run_health_server(port: int, is_healthy: callable) -> web.AppRunner:
+async def run_health_server(port: int, is_healthy: Callable[[], bool]) -> web.AppRunner:
     """Start the health endpoint HTTP server.
 
     Args:

--- a/hls-ingest/ingest.py
+++ b/hls-ingest/ingest.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import subprocess
+import threading
 import time
 
 from config import Config
@@ -75,6 +76,7 @@ class IngestProcess:
         self.process: subprocess.Popen | None = None
         self.running: bool = False
         self._last_start_time: float = 0.0
+        self._stderr_thread: threading.Thread | None = None
 
     def start(self) -> None:
         """Launch the ffmpeg process."""
@@ -86,7 +88,27 @@ class IngestProcess:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
         )
+        self._stderr_thread = threading.Thread(
+            target=self._drain_stderr,
+            args=(self.process.stderr,),
+            daemon=True,
+        )
+        self._stderr_thread.start()
         self._last_start_time = time.monotonic()
+
+    def _drain_stderr(self, stream) -> None:
+        """Read lines from the ffmpeg stderr pipe and log them.
+
+        Runs in a daemon thread to prevent the 64KB pipe buffer from filling,
+        which would deadlock ffmpeg and cause process.wait() to hang.
+        """
+        try:
+            for line in stream:
+                decoded = line.decode("utf-8", errors="replace").rstrip()
+                if decoded:
+                    logger.debug("ffmpeg: %s", decoded)
+        except ValueError:
+            pass  # Stream was closed
 
     def stop(self) -> None:
         """Gracefully stop the ffmpeg process."""

--- a/hls-ingest/main.py
+++ b/hls-ingest/main.py
@@ -5,6 +5,7 @@ Orchestrates ffmpeg ingest, S3 upload, and health endpoint.
 
 import asyncio
 import logging
+import shutil
 import signal
 import sys
 import tempfile
@@ -83,6 +84,7 @@ def main() -> None:
     finally:
         uploader.stop()
         loop.call_soon_threadsafe(loop.stop)
+        shutil.rmtree(output_dir, ignore_errors=True)
         logger.info("Shutdown complete")
 
 

--- a/hls-ingest/requirements.txt
+++ b/hls-ingest/requirements.txt
@@ -3,6 +3,7 @@ watchdog>=4.0,<5
 aiohttp>=3.9,<4
 pytest>=8.0,<9
 pytest-asyncio>=0.23,<1
+pytest-aiohttp>=1.0,<2
 moto[s3]>=5.0,<6
 black>=24.0
 ruff>=0.3

--- a/hls-ingest/scripts/provision-aws.sh
+++ b/hls-ingest/scripts/provision-aws.sh
@@ -52,10 +52,20 @@ aws s3api put-bucket-lifecycle-configuration --bucket "$BUCKET" \
                 "Expiration": {
                     "Days": 2
                 }
+            },
+            {
+                "ID": "expire-old-versions",
+                "Status": "Enabled",
+                "Filter": {
+                    "Prefix": "live/"
+                },
+                "NoncurrentVersionExpiration": {
+                    "NoncurrentDays": 1
+                }
             }
         ]
     }'
-echo "Configured lifecycle rule (expire after 2 days)"
+echo "Configured lifecycle rules (expire segments after 2 days, old versions after 1 day)"
 
 # CORS configuration for browser-based HLS playback
 aws s3api put-bucket-cors --bucket "$BUCKET" \
@@ -71,22 +81,14 @@ aws s3api put-bucket-cors --bucket "$BUCKET" \
     }'
 echo "Configured CORS for HLS playback"
 
-# Bucket policy: allow public read for the live/ prefix
-aws s3api put-bucket-policy --bucket "$BUCKET" \
-    --policy "{
-        \"Version\": \"2012-10-17\",
-        \"Statement\": [
-            {
-                \"Sid\": \"PublicReadHLS\",
-                \"Effect\": \"Allow\",
-                \"Principal\": \"*\",
-                \"Action\": \"s3:GetObject\",
-                \"Resource\": \"arn:aws:s3:::$BUCKET/live/*\"
-            }
-        ]
-    }"
-echo "Configured public read policy for live/ prefix"
+# NOTE: Do not grant public read access directly on the bucket. Instead,
+# configure a CloudFront Origin Access Control (OAC) to restrict S3 access
+# to CloudFront only. The OAC should be created as part of the CloudFront
+# distribution setup, which is outside the scope of this provisioning script.
+#
+# See: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/private-content-restricting-access-to-s3.html
 
 echo ""
-echo "Provisioning complete. Stream URL will be:"
-echo "  https://$BUCKET.s3.$REGION.amazonaws.com/live/live.m3u8"
+echo "Provisioning complete."
+echo "Configure a CloudFront distribution with OAC to serve:"
+echo "  https://<distribution>.cloudfront.net/live/live.m3u8"

--- a/hls-ingest/tests/test_health.py
+++ b/hls-ingest/tests/test_health.py
@@ -1,10 +1,6 @@
 """Tests for the health endpoint under various states."""
 
-import json
-
 import pytest
-from aiohttp import web
-from aiohttp.test_utils import AioHTTPTestCase, TestClient, TestServer
 
 from health import create_health_app
 
@@ -55,3 +51,26 @@ async def test_unknown_route_returns_404(healthy_app, aiohttp_client):
     client = await aiohttp_client(healthy_app)
     resp = await client.get("/nonexistent")
     assert resp.status == 404
+
+
+class TestHealthTypeAnnotations:
+    """Verify proper type annotations instead of bare builtin callable."""
+
+    def test_create_health_app_uses_callable_type(self):
+        import inspect
+
+        sig = inspect.signature(create_health_app)
+        param = sig.parameters["is_healthy"]
+        assert (
+            param.annotation is not callable
+        ), "is_healthy should use Callable[[], bool], not the builtin callable"
+
+    def test_run_health_server_uses_callable_type(self):
+        import inspect
+        from health import run_health_server
+
+        sig = inspect.signature(run_health_server)
+        param = sig.parameters["is_healthy"]
+        assert (
+            param.annotation is not callable
+        ), "is_healthy should use Callable[[], bool], not the builtin callable"

--- a/hls-ingest/tests/test_ingest.py
+++ b/hls-ingest/tests/test_ingest.py
@@ -4,9 +4,7 @@ import os
 import subprocess
 from unittest.mock import MagicMock, patch
 
-import pytest
 
-from config import Config
 from ingest import IngestProcess, build_ffmpeg_args
 
 
@@ -119,7 +117,9 @@ class TestIngestProcess:
 
     @patch("ingest.subprocess.Popen")
     @patch("ingest.time.sleep")
-    def test_run_forever_restarts_on_crash(self, mock_sleep, mock_popen, sample_config, tmp_output_dir):
+    def test_run_forever_restarts_on_crash(
+        self, mock_sleep, mock_popen, sample_config, tmp_output_dir
+    ):
         """Verify that run_forever restarts ffmpeg after a crash."""
         call_count = 0
 
@@ -141,3 +141,47 @@ class TestIngestProcess:
 
         assert call_count == 2
         assert mock_popen.call_count == 2
+
+
+class TestStderrDraining:
+    """Tests for stderr pipe draining to prevent subprocess deadlock."""
+
+    @patch("ingest.subprocess.Popen")
+    def test_start_launches_stderr_drain_thread(self, mock_popen, sample_config, tmp_output_dir):
+        """Verify that starting ffmpeg also starts a daemon thread to drain stderr."""
+        mock_process = MagicMock()
+        mock_process.stderr = MagicMock()
+        mock_popen.return_value = mock_process
+
+        proc = IngestProcess(sample_config, tmp_output_dir)
+
+        with patch("ingest.threading.Thread") as mock_thread_cls:
+            mock_thread = MagicMock()
+            mock_thread_cls.return_value = mock_thread
+
+            proc.start()
+
+            mock_thread_cls.assert_called_once()
+            assert mock_thread_cls.call_args.kwargs.get("daemon") is True
+            mock_thread.start.assert_called_once()
+
+    def test_drain_stderr_logs_lines(self, sample_config, tmp_output_dir):
+        """Verify that _drain_stderr reads and logs each line from the pipe."""
+        import io
+
+        proc = IngestProcess(sample_config, tmp_output_dir)
+        fake_stderr = io.BytesIO(b"frame=100 fps=25\nsize=1024kB time=00:00:04\n")
+
+        with patch("ingest.logger") as mock_logger:
+            proc._drain_stderr(fake_stderr)
+            assert mock_logger.debug.call_count == 2
+
+    def test_drain_stderr_handles_empty_stream(self, sample_config, tmp_output_dir):
+        """Verify _drain_stderr handles EOF gracefully."""
+        import io
+
+        proc = IngestProcess(sample_config, tmp_output_dir)
+        fake_stderr = io.BytesIO(b"")
+
+        # Should not raise
+        proc._drain_stderr(fake_stderr)

--- a/hls-ingest/tests/test_integration.py
+++ b/hls-ingest/tests/test_integration.py
@@ -5,15 +5,14 @@ These tests require ffmpeg to be installed and are marked with
 """
 
 import os
-import time
 
 import boto3
 import pytest
 from moto import mock_aws
 
 from config import Config
-from ingest import IngestProcess, build_ffmpeg_args
-from uploader import UploadWorker, upload_with_retry
+from ingest import build_ffmpeg_args
+from uploader import upload_with_retry
 
 
 @pytest.fixture

--- a/hls-ingest/tests/test_main.py
+++ b/hls-ingest/tests/test_main.py
@@ -1,0 +1,56 @@
+"""Tests for the main module orchestration."""
+
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+
+class TestMainCleanup:
+    """Tests for resource cleanup in main()."""
+
+    @patch("main.threading.Thread")
+    @patch("main.asyncio.new_event_loop")
+    @patch("main.signal.signal")
+    @patch("main.boto3.client")
+    @patch("main.UploadWorker")
+    @patch("main.IngestProcess")
+    @patch("main.Config.from_env")
+    def test_output_dir_cleaned_up_on_normal_exit(
+        self,
+        mock_from_env,
+        mock_ingest_cls,
+        mock_uploader_cls,
+        mock_boto3_client,
+        mock_signal,
+        mock_loop,
+        mock_thread,
+    ):
+        """Verify the temp output directory is removed when main() exits."""
+        mock_config = MagicMock()
+        mock_config.health_port = 8090
+        mock_from_env.return_value = mock_config
+
+        mock_ingest = MagicMock()
+        mock_ingest.run_forever.return_value = None
+        mock_ingest_cls.return_value = mock_ingest
+
+        mock_uploader_cls.return_value = MagicMock()
+        mock_thread.return_value = MagicMock()
+
+        captured_dir = {}
+        original_mkdtemp = tempfile.mkdtemp
+
+        def tracking_mkdtemp(**kwargs):
+            d = original_mkdtemp(**kwargs)
+            captured_dir["path"] = d
+            return d
+
+        with patch("main.tempfile.mkdtemp", side_effect=tracking_mkdtemp):
+            from main import main
+
+            main()
+
+        assert "path" in captured_dir
+        assert not os.path.exists(
+            captured_dir["path"]
+        ), f"Temp directory {captured_dir['path']} should have been cleaned up"

--- a/hls-ingest/tests/test_uploader.py
+++ b/hls-ingest/tests/test_uploader.py
@@ -1,13 +1,14 @@
-"""Tests for S3 uploads: segment detection, retry logic, content types."""
+"""Tests for S3 uploads: segment detection, retry logic, content types, ordering."""
 
 import os
-import time
+import queue
 from unittest.mock import MagicMock, call, patch
 
-import pytest
+from watchdog.events import FileClosedEvent, FileSystemEventHandler
 
 from uploader import (
     HLSUploadHandler,
+    UploadWorkerThread,
     content_type_for_file,
     s3_key_for_file,
     upload_with_retry,
@@ -81,7 +82,12 @@ class TestUploadWithRetry:
         mock_client.upload_file.side_effect = Exception("fail")
 
         upload_with_retry(
-            mock_client, "/tmp/seg.ts", "bucket", "live/seg.ts", max_retries=3, base_backoff=1.0
+            mock_client,
+            "/tmp/seg.ts",
+            "bucket",
+            "live/seg.ts",
+            max_retries=3,
+            base_backoff=1.0,
         )
 
         assert mock_sleep.call_args_list == [call(1.0), call(2.0), call(4.0)]
@@ -111,52 +117,161 @@ class TestUploadWithRetry:
         assert kwargs["ExtraArgs"] is None
 
 
-class TestHLSUploadHandler:
-    """Tests for the watchdog event handler."""
+class TestHLSUploadHandlerOnClosed:
+    """Tests that the handler uses on_closed and enqueues paths."""
 
-    def test_handles_ts_file_creation(self, tmp_output_dir):
-        mock_client = MagicMock()
-        handler = HLSUploadHandler(mock_client, "bucket", "live")
+    def test_on_closed_enqueues_ts_file(self, tmp_output_dir):
+        q = queue.Queue()
+        handler = HLSUploadHandler(q)
 
         ts_path = os.path.join(tmp_output_dir, "seg_00001.ts")
         with open(ts_path, "wb") as f:
             f.write(b"\x00" * 100)
 
-        from watchdog.events import FileCreatedEvent
+        event = FileClosedEvent(ts_path)
+        handler.on_closed(event)
 
-        event = FileCreatedEvent(ts_path)
-        with patch("uploader.upload_with_retry") as mock_upload:
-            handler.on_created(event)
-            mock_upload.assert_called_once_with(
-                mock_client, ts_path, "bucket", "live/seg_00001.ts"
-            )
+        assert not q.empty()
+        assert q.get_nowait() == ts_path
 
-    def test_ignores_non_hls_files(self, tmp_output_dir):
-        mock_client = MagicMock()
-        handler = HLSUploadHandler(mock_client, "bucket", "live")
-
-        txt_path = os.path.join(tmp_output_dir, "notes.txt")
-        with open(txt_path, "w") as f:
-            f.write("hello")
-
-        from watchdog.events import FileCreatedEvent
-
-        event = FileCreatedEvent(txt_path)
-        with patch("uploader.upload_with_retry") as mock_upload:
-            handler.on_created(event)
-            mock_upload.assert_not_called()
-
-    def test_handles_m3u8_modification(self, tmp_output_dir):
-        mock_client = MagicMock()
-        handler = HLSUploadHandler(mock_client, "bucket", "live")
+    def test_on_closed_enqueues_m3u8_file(self, tmp_output_dir):
+        q = queue.Queue()
+        handler = HLSUploadHandler(q)
 
         m3u8_path = os.path.join(tmp_output_dir, "live.m3u8")
         with open(m3u8_path, "w") as f:
             f.write("#EXTM3U\n")
 
-        from watchdog.events import FileModifiedEvent
+        event = FileClosedEvent(m3u8_path)
+        handler.on_closed(event)
 
-        event = FileModifiedEvent(m3u8_path)
-        with patch("uploader.upload_with_retry") as mock_upload:
-            handler.on_modified(event)
-            mock_upload.assert_called_once()
+        assert not q.empty()
+        assert q.get_nowait() == m3u8_path
+
+    def test_on_closed_ignores_non_hls_files(self, tmp_output_dir):
+        q = queue.Queue()
+        handler = HLSUploadHandler(q)
+
+        txt_path = os.path.join(tmp_output_dir, "notes.txt")
+        with open(txt_path, "w") as f:
+            f.write("hello")
+
+        event = FileClosedEvent(txt_path)
+        handler.on_closed(event)
+
+        assert q.empty()
+
+    def test_handler_does_not_override_on_created(self):
+        q = queue.Queue()
+        handler = HLSUploadHandler(q)
+        assert type(handler).on_created is FileSystemEventHandler.on_created
+
+    def test_handler_does_not_override_on_modified(self):
+        q = queue.Queue()
+        handler = HLSUploadHandler(q)
+        assert type(handler).on_modified is FileSystemEventHandler.on_modified
+
+
+class TestUploadWorkerThread:
+    """Tests for the queue-based upload worker thread."""
+
+    @patch("uploader.upload_with_retry")
+    def test_processes_ts_file_immediately(self, mock_upload, tmp_output_dir):
+        q = queue.Queue()
+        mock_s3 = MagicMock()
+        worker = UploadWorkerThread(mock_s3, "bucket", "live", q)
+
+        ts_path = os.path.join(tmp_output_dir, "seg_00001.ts")
+        with open(ts_path, "wb") as f:
+            f.write(b"\x00" * 100)
+
+        q.put(ts_path)
+        q.put(None)  # sentinel
+
+        worker.run()
+
+        mock_upload.assert_called_once_with(mock_s3, ts_path, "bucket", "live/seg_00001.ts")
+
+    @patch("uploader.upload_with_retry")
+    def test_defers_m3u8_until_queue_drains(self, mock_upload, tmp_output_dir):
+        """Playlist upload is deferred; segments in the queue are uploaded first."""
+        q = queue.Queue()
+        mock_s3 = MagicMock()
+        worker = UploadWorkerThread(mock_s3, "bucket", "live", q, playlist_defer_secs=0.01)
+
+        ts_path = os.path.join(tmp_output_dir, "seg_00001.ts")
+        with open(ts_path, "wb") as f:
+            f.write(b"\x00" * 100)
+
+        m3u8_path = os.path.join(tmp_output_dir, "live.m3u8")
+        with open(m3u8_path, "w") as f:
+            f.write("#EXTM3U\n")
+
+        # Enqueue playlist BEFORE segment — worker should still upload segment first
+        q.put(m3u8_path)
+        q.put(ts_path)
+        q.put(None)
+
+        worker.run()
+
+        calls = [c.args[1] for c in mock_upload.call_args_list]
+        assert calls.index(ts_path) < calls.index(m3u8_path)
+
+    @patch("uploader.upload_with_retry")
+    def test_stops_on_sentinel(self, mock_upload):
+        q = queue.Queue()
+        mock_s3 = MagicMock()
+        worker = UploadWorkerThread(mock_s3, "bucket", "live", q)
+
+        q.put(None)
+        worker.run()
+
+        mock_upload.assert_not_called()
+
+    @patch("uploader.upload_with_retry")
+    def test_handles_multiple_segments_before_playlist(self, mock_upload, tmp_output_dir):
+        q = queue.Queue()
+        mock_s3 = MagicMock()
+        worker = UploadWorkerThread(mock_s3, "bucket", "live", q, playlist_defer_secs=0.01)
+
+        paths = []
+        for i in range(3):
+            ts_path = os.path.join(tmp_output_dir, f"seg_{i:05d}.ts")
+            with open(ts_path, "wb") as f:
+                f.write(b"\x00" * 100)
+            paths.append(ts_path)
+
+        m3u8_path = os.path.join(tmp_output_dir, "live.m3u8")
+        with open(m3u8_path, "w") as f:
+            f.write("#EXTM3U\n")
+
+        q.put(m3u8_path)
+        for p in paths:
+            q.put(p)
+        q.put(None)
+
+        worker.run()
+
+        upload_paths = [c.args[1] for c in mock_upload.call_args_list]
+        # All 3 segments should be uploaded before the playlist
+        m3u8_idx = upload_paths.index(m3u8_path)
+        for p in paths:
+            assert upload_paths.index(p) < m3u8_idx
+
+    @patch("uploader.upload_with_retry")
+    def test_flushes_deferred_playlist_on_shutdown(self, mock_upload, tmp_output_dir):
+        """When sentinel arrives, any deferred playlist is still uploaded."""
+        q = queue.Queue()
+        mock_s3 = MagicMock()
+        worker = UploadWorkerThread(mock_s3, "bucket", "live", q, playlist_defer_secs=0.01)
+
+        m3u8_path = os.path.join(tmp_output_dir, "live.m3u8")
+        with open(m3u8_path, "w") as f:
+            f.write("#EXTM3U\n")
+
+        q.put(m3u8_path)
+        q.put(None)
+
+        worker.run()
+
+        mock_upload.assert_called_once_with(mock_s3, m3u8_path, "bucket", "live/live.m3u8")

--- a/hls-ingest/uploader.py
+++ b/hls-ingest/uploader.py
@@ -1,11 +1,19 @@
-"""S3 upload worker that watches for new HLS segments and uploads them."""
+"""S3 upload worker that watches for completed HLS files and uploads them.
+
+Uses watchdog's FileClosedEvent (inotify on Linux) to detect when ffmpeg
+finishes writing a segment or playlist, then uploads via a separate worker
+thread to avoid blocking the observer. Playlists are deferred until the
+queue drains, ensuring segments reach S3 before the playlist references them.
+"""
 
 import logging
 import os
+import queue
+import threading
 import time
 from typing import Protocol
 
-from watchdog.events import FileCreatedEvent, FileModifiedEvent, FileSystemEventHandler
+from watchdog.events import FileClosedEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
 logger = logging.getLogger(__name__)
@@ -19,6 +27,9 @@ CONTENT_TYPES = {
 # Retry configuration for S3 uploads.
 MAX_RETRIES = 3
 BASE_BACKOFF = 1.0
+
+# Default seconds to wait for more segments before uploading a deferred playlist.
+DEFAULT_PLAYLIST_DEFER_SECS = 2.0
 
 
 class S3Client(Protocol):
@@ -101,64 +112,115 @@ def upload_with_retry(
 
 
 class HLSUploadHandler(FileSystemEventHandler):
-    """Watchdog handler that uploads new/modified HLS files to S3.
+    """Watchdog handler that enqueues closed HLS files for upload.
 
-    Monitors a directory for .ts and .m3u8 file events and uploads them
-    to the configured S3 bucket with appropriate content types.
+    Only responds to on_closed events (FileClosedEvent), ensuring files are
+    fully written before being queued. This requires inotify (Linux); the
+    production Docker container runs on Linux.
     """
 
-    def __init__(self, s3_client: S3Client, bucket: str, prefix: str) -> None:
+    def __init__(self, upload_queue: queue.Queue) -> None:
         super().__init__()
+        self._queue = upload_queue
+
+    def on_closed(self, event: FileClosedEvent) -> None:
+        """Enqueue HLS files when they are closed after writing."""
+        if event.is_directory:
+            return
+        filename = os.path.basename(event.src_path)
+        _, ext = os.path.splitext(filename)
+        if ext in CONTENT_TYPES:
+            self._queue.put(event.src_path)
+
+
+class UploadWorkerThread:
+    """Drains an upload queue, uploading segments immediately and deferring playlists.
+
+    Segments (.ts) are uploaded as soon as they are dequeued. Playlists (.m3u8)
+    are held back until no new items arrive for ``playlist_defer_secs``, ensuring
+    segments reach S3 before the playlist references them.
+
+    A None sentinel in the queue signals the thread to stop.
+    """
+
+    def __init__(
+        self,
+        s3_client: S3Client,
+        bucket: str,
+        prefix: str,
+        upload_queue: queue.Queue,
+        playlist_defer_secs: float = DEFAULT_PLAYLIST_DEFER_SECS,
+    ) -> None:
         self.s3_client = s3_client
         self.bucket = bucket
         self.prefix = prefix
+        self._queue = upload_queue
+        self._playlist_defer_secs = playlist_defer_secs
 
-    def on_created(self, event: FileCreatedEvent) -> None:
-        """Handle new file creation events."""
-        if not event.is_directory:
-            self._handle_file(event.src_path)
+    def run(self) -> None:
+        """Process the upload queue until a None sentinel is received."""
+        deferred_playlist: str | None = None
 
-    def on_modified(self, event: FileModifiedEvent) -> None:
-        """Handle file modification events (for playlist updates)."""
-        if not event.is_directory:
-            self._handle_file(event.src_path)
+        while True:
+            timeout = self._playlist_defer_secs if deferred_playlist else None
+            try:
+                path = self._queue.get(timeout=timeout)
+            except queue.Empty:
+                # Timeout expired — upload the deferred playlist now
+                if deferred_playlist:
+                    self._upload(deferred_playlist)
+                    deferred_playlist = None
+                continue
 
-    def _handle_file(self, path: str) -> None:
-        """Upload a file if it has an HLS-related extension."""
+            if path is None:
+                # Sentinel: upload any remaining deferred playlist, then exit
+                if deferred_playlist:
+                    self._upload(deferred_playlist)
+                break
+
+            _, ext = os.path.splitext(path)
+            if ext == ".m3u8":
+                # Defer playlist; upload any previously deferred one first
+                if deferred_playlist:
+                    self._upload(deferred_playlist)
+                deferred_playlist = path
+            else:
+                self._upload(path)
+
+    def _upload(self, path: str) -> None:
+        """Upload a single file to S3."""
         filename = os.path.basename(path)
-        _, ext = os.path.splitext(filename)
-        if ext not in CONTENT_TYPES:
-            return
-
         key = s3_key_for_file(self.prefix, filename)
         upload_with_retry(self.s3_client, path, self.bucket, key)
 
 
 class UploadWorker:
-    """Watches a directory for new HLS segments and uploads them to S3.
+    """Watches a directory for completed HLS files and uploads them to S3.
 
-    Uses watchdog's Observer to monitor the filesystem and trigger uploads
-    via HLSUploadHandler.
-
-    Attributes:
-        observer: The watchdog Observer instance.
-        watch_dir: Directory being monitored.
+    Uses watchdog's Observer to detect file close events and a separate
+    thread to perform uploads, ensuring retries don't block event dispatch.
     """
 
     def __init__(self, s3_client: S3Client, bucket: str, prefix: str, watch_dir: str) -> None:
         self.watch_dir = watch_dir
-        self.handler = HLSUploadHandler(s3_client, bucket, prefix)
+        self._queue: queue.Queue = queue.Queue()
+        self.handler = HLSUploadHandler(self._queue)
+        self._worker = UploadWorkerThread(s3_client, bucket, prefix, self._queue)
         self.observer = Observer()
+        self._upload_thread = threading.Thread(target=self._worker.run, daemon=True)
 
     def start(self) -> None:
-        """Start watching the directory for new files."""
+        """Start watching the directory and uploading files."""
         os.makedirs(self.watch_dir, exist_ok=True)
         self.observer.schedule(self.handler, self.watch_dir, recursive=False)
         self.observer.start()
+        self._upload_thread.start()
         logger.info("Upload worker watching %s", self.watch_dir)
 
     def stop(self) -> None:
-        """Stop the directory watcher."""
+        """Stop the directory watcher and upload thread."""
         self.observer.stop()
         self.observer.join(timeout=10)
+        self._queue.put(None)  # sentinel to stop worker thread
+        self._upload_thread.join(timeout=10)
         logger.info("Upload worker stopped")


### PR DESCRIPTION
## Summary

- Fix critical ffmpeg stderr pipe deadlock by draining stderr in a daemon thread
- Rewrite upload pipeline: use `FileClosedEvent` for complete file detection, queue-based `UploadWorkerThread` for decoupled upload with playlist deferral (fixes partial uploads, playlist/segment race, and blocking retry)
- Add `NoncurrentVersionExpiration` S3 lifecycle rule to expire old playlist versions
- Remove public bucket policy, add CloudFront OAC guidance
- Fix temp directory leak on shutdown
- Fix `callable` type hint to `Callable[[], bool]`
- Add missing `pytest-aiohttp` dependency

Closes #3

## Test plan

- [x] 65 unit tests passing (13 new), 0 failures
- [x] black --check clean (100 char line length)
- [x] ruff check clean
- [x] provision-aws.sh syntax check passes (`bash -n`)
- [x] Integration test with real ffmpeg on Linux (Docker)
- [x] Verify `FileClosedEvent` fires correctly on Linux/inotify (macOS uses FSEvents which doesn't emit close events)