### PR TITLE
Add CloudFormation deployment for hls-ingest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-          cache-dependency-path: hls-ingest/requirements.txt
+          cache-dependency-path: hls-ingest/requirements-dev.txt
 
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-dev.txt
 
       - name: Lint (ruff)
         run: ruff check .

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ __pycache__/
 .eggs/
 dist/
 build/
+
+# Deploy config (contains account-specific AWS resource IDs)
+hls-ingest/infra/env.*.conf

--- a/hls-ingest/CLAUDE.md
+++ b/hls-ingest/CLAUDE.md
@@ -10,12 +10,19 @@ HLS ingest service that captures the WXYC ibiblio MP3 stream, segments it into H
 - `uploader.py` -- Watches the output directory for new .ts/.m3u8 files and uploads them to S3 with retry.
 - `health.py` -- HTTP health endpoint at :8090/health reporting ffmpeg status.
 
+## Infrastructure
+
+- `infra/template.yaml` -- CloudFormation template. Parameterized for staging and production via `Environment` parameter. Creates: S3 bucket, CloudFront distribution (OAC, HTTPS, custom domain), ECS Fargate service, IAM roles, Route 53 DNS record.
+- `infra/deploy.sh` -- Builds the Docker image, pushes to ECR, and deploys the CloudFormation stack. Usage: `./infra/deploy.sh <staging|production> [image-tag]`.
+- `infra/env.<env>.conf` -- Environment-specific AWS resource IDs (VPC, subnets, hosted zone, ACM cert). Gitignored. Copy from `.example` and fill in your values.
+- `scripts/provision-aws.sh` -- Deprecated. Replaced by the CloudFormation template.
+
 ## Development
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 pytest                           # unit tests only
 pytest -m integration            # integration tests (requires ffmpeg)
 ```
@@ -34,8 +41,8 @@ pytest -m integration            # integration tests (requires ffmpeg)
 | `S3_BUCKET` | `wxyc-hls` | No | Target S3 bucket |
 | `S3_PREFIX` | `live` | No | S3 key prefix |
 | `AWS_REGION` | `us-east-1` | No | AWS region |
-| `AWS_ACCESS_KEY_ID` | -- | Yes | AWS credentials |
-| `AWS_SECRET_ACCESS_KEY` | -- | Yes | AWS credentials |
+| `AWS_ACCESS_KEY_ID` | -- | Local only | AWS credentials. Not needed on ECS Fargate (task role provides credentials automatically). |
+| `AWS_SECRET_ACCESS_KEY` | -- | Local only | AWS credentials. Not needed on ECS Fargate (task role provides credentials automatically). |
 | `HLS_SEGMENT_DURATION` | `6` | No | Segment length in seconds |
 | `HLS_LIST_SIZE` | `600` | No | Max segments in playlist |
 | `HEALTH_PORT` | `8090` | No | Health endpoint port |
@@ -45,4 +52,30 @@ pytest -m integration            # integration tests (requires ffmpeg)
 ```bash
 docker build -t hls-ingest .
 docker run -e AWS_ACCESS_KEY_ID=... -e AWS_SECRET_ACCESS_KEY=... hls-ingest
+```
+
+## Deployment
+
+Prerequisites: AWS CLI configured, a VPC with public subnets, a Route 53 hosted zone for wxyc.org, and an ACM certificate in us-east-1 covering hls.wxyc.org / hls-staging.wxyc.org.
+
+First deploy:
+
+```bash
+cd infra
+cp env.staging.conf.example env.staging.conf
+# Fill in VPC_ID, SUBNET_IDS, HOSTED_ZONE_ID, CERTIFICATE_ARN
+./deploy.sh staging
+```
+
+Subsequent deploys (auto-tags with git SHA):
+
+```bash
+./infra/deploy.sh staging
+```
+
+Check status:
+
+```bash
+aws ecs describe-services --cluster hls-ingest-staging --services hls-ingest-staging
+aws cloudformation describe-stacks --stack-name hls-ingest-staging
 ```

--- a/hls-ingest/README.md
+++ b/hls-ingest/README.md
@@ -16,12 +16,12 @@ HLS ingest service for WXYC 89.3 FM. Captures the ibiblio MP3 stream, transcodes
 # Set up
 python -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 
 # Run tests
 pytest
 
-# Run the service (requires AWS credentials)
+# Run the service (requires AWS credentials for local dev)
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
 python main.py
@@ -38,13 +38,18 @@ docker run \
   hls-ingest
 ```
 
-## AWS Provisioning
+## Deployment
 
-The `scripts/provision-aws.sh` script creates the S3 bucket with lifecycle rules, CORS, and a public read policy:
+Deploy to AWS (ECS Fargate + S3 + CloudFront) using the CloudFormation template:
 
 ```bash
-./scripts/provision-aws.sh [bucket-name] [region]
+cd infra
+cp env.staging.conf.example env.staging.conf
+# Fill in VPC_ID, SUBNET_IDS, HOSTED_ZONE_ID, CERTIFICATE_ARN
+./deploy.sh staging
 ```
+
+See `CLAUDE.md` for full deployment documentation and prerequisites.
 
 ## Configuration
 

--- a/hls-ingest/config.py
+++ b/hls-ingest/config.py
@@ -22,11 +22,13 @@ class Config:
     def from_env(cls) -> "Config":
         """Load configuration from environment variables.
 
-        Required:
-            AWS_ACCESS_KEY_ID: AWS access key for S3 uploads.
-            AWS_SECRET_ACCESS_KEY: AWS secret key for S3 uploads.
+        Optional (with defaults).
 
-        Optional (with defaults):
+        AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are optional. When omitted,
+        boto3 discovers credentials from the environment (e.g., IAM task role
+        on ECS Fargate). Set them explicitly for local development.
+
+        Other optional variables:
             IBIBLIO_STREAM_URL: Source MP3 stream URL (default: https://audio-mp3.ibiblio.org/wxyc.mp3).
             S3_BUCKET: Target S3 bucket name (default: wxyc-hls).
             S3_PREFIX: Key prefix for uploaded objects (default: live).
@@ -45,8 +47,6 @@ class Config:
 
         aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID", "")
         aws_secret_access_key = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
-        if not aws_access_key_id or not aws_secret_access_key:
-            raise ValueError("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required")
 
         return cls(
             stream_url=os.environ.get(

--- a/hls-ingest/infra/deploy.sh
+++ b/hls-ingest/infra/deploy.sh
@@ -52,7 +52,7 @@ fi
 # shellcheck source=/dev/null
 source "$CONF_FILE"
 
-for var in VPC_ID SUBNET_IDS HOSTED_ZONE_ID CERTIFICATE_ARN; do
+for var in VPC_ID SUBNET_IDS CERTIFICATE_ARN; do
     if [[ -z "${!var:-}" ]]; then
         echo "Error: $var is not set in $CONF_FILE"
         exit 1
@@ -133,7 +133,6 @@ aws cloudformation deploy \
         "Environment=$ENV" \
         "VpcId=$VPC_ID" \
         "SubnetIds=$SUBNET_IDS" \
-        "HostedZoneId=$HOSTED_ZONE_ID" \
         "CertificateArn=$CERTIFICATE_ARN" \
         "ImageTag=$IMAGE_TAG" \
     --capabilities CAPABILITY_NAMED_IAM \

--- a/hls-ingest/infra/deploy.sh
+++ b/hls-ingest/infra/deploy.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+#
+# Build, push, and deploy the HLS ingest service to AWS.
+#
+# Usage:
+#   ./deploy.sh <staging|production> [image-tag]
+#
+# The script reads AWS resource IDs from infra/env.<environment>.conf.
+# Copy the .example file and fill in your values before first use.
+#
+# Prerequisites:
+#   - AWS CLI configured (aws sts get-caller-identity works)
+#   - Docker installed
+#   - env.<environment>.conf filled in
+#
+# What it does:
+#   1. Creates the ECR repository if it doesn't exist
+#   2. Builds and pushes the Docker image
+#   3. Deploys (or updates) the CloudFormation stack
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVICE_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_NAME="wxyc/hls-ingest"
+STACK_PREFIX="hls-ingest"
+
+# ── Parse arguments ──────────────────────────────────────────────────────────
+
+ENV="${1:-}"
+IMAGE_TAG="${2:-$(git -C "$SERVICE_DIR" rev-parse --short HEAD)}"
+
+if [[ -z "$ENV" ]] || [[ "$ENV" != "staging" && "$ENV" != "production" ]]; then
+    echo "Usage: $0 <staging|production> [image-tag]"
+    echo ""
+    echo "  image-tag defaults to the current git short SHA ($IMAGE_TAG)"
+    exit 1
+fi
+
+# ── Load environment config ──────────────────────────────────────────────────
+
+CONF_FILE="$SCRIPT_DIR/env.${ENV}.conf"
+
+if [[ ! -f "$CONF_FILE" ]]; then
+    echo "Error: $CONF_FILE not found."
+    echo ""
+    echo "  cp $SCRIPT_DIR/env.${ENV}.conf.example $CONF_FILE"
+    echo "  # Fill in your AWS resource IDs, then re-run this script."
+    exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$CONF_FILE"
+
+for var in VPC_ID SUBNET_IDS HOSTED_ZONE_ID CERTIFICATE_ARN; do
+    if [[ -z "${!var:-}" ]]; then
+        echo "Error: $var is not set in $CONF_FILE"
+        exit 1
+    fi
+done
+
+# ── Resolve AWS account and region ───────────────────────────────────────────
+
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+REGION="$(aws configure get region || echo "us-east-1")"
+ECR_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
+
+echo "╔══════════════════════════════════════════════════════╗"
+echo "║  WXYC HLS Ingest — Deploy                          ║"
+echo "╠══════════════════════════════════════════════════════╣"
+echo "║  Environment:  $ENV"
+echo "║  Image tag:    $IMAGE_TAG"
+echo "║  Account:      $ACCOUNT_ID"
+echo "║  Region:       $REGION"
+echo "╚══════════════════════════════════════════════════════╝"
+echo ""
+
+# ── ECR repository ───────────────────────────────────────────────────────────
+
+echo "▶ Checking ECR repository..."
+if ! aws ecr describe-repositories --repository-names "$REPO_NAME" --region "$REGION" >/dev/null 2>&1; then
+    echo "  Creating ECR repository: $REPO_NAME"
+    aws ecr create-repository \
+        --repository-name "$REPO_NAME" \
+        --region "$REGION" \
+        --image-scanning-configuration scanOnPush=true \
+        --image-tag-mutability MUTABLE >/dev/null
+    # Keep only the last 10 images to avoid unbounded storage growth.
+    aws ecr put-lifecycle-policy \
+        --repository-name "$REPO_NAME" \
+        --region "$REGION" \
+        --lifecycle-policy-text '{
+            "rules": [{
+                "rulePriority": 1,
+                "description": "Keep last 10 images",
+                "selection": {
+                    "tagStatus": "any",
+                    "countType": "imageCountMoreThan",
+                    "countNumber": 10
+                },
+                "action": { "type": "expire" }
+            }]
+        }' >/dev/null
+    echo "  ✓ Created"
+else
+    echo "  ✓ Already exists"
+fi
+
+# ── Build and push Docker image ──────────────────────────────────────────────
+
+echo ""
+echo "▶ Building Docker image..."
+docker build -t "$REPO_NAME:$IMAGE_TAG" "$SERVICE_DIR"
+
+echo ""
+echo "▶ Pushing to ECR..."
+aws ecr get-login-password --region "$REGION" | \
+    docker login --username AWS --password-stdin "$ECR_URI"
+docker tag "$REPO_NAME:$IMAGE_TAG" "$ECR_URI/$REPO_NAME:$IMAGE_TAG"
+docker push "$ECR_URI/$REPO_NAME:$IMAGE_TAG"
+echo "  ✓ Pushed $ECR_URI/$REPO_NAME:$IMAGE_TAG"
+
+# ── Deploy CloudFormation stack ──────────────────────────────────────────────
+
+STACK_NAME="${STACK_PREFIX}-${ENV}"
+
+echo ""
+echo "▶ Deploying CloudFormation stack: $STACK_NAME"
+aws cloudformation deploy \
+    --template-file "$SCRIPT_DIR/template.yaml" \
+    --stack-name "$STACK_NAME" \
+    --parameter-overrides \
+        "Environment=$ENV" \
+        "VpcId=$VPC_ID" \
+        "SubnetIds=$SUBNET_IDS" \
+        "HostedZoneId=$HOSTED_ZONE_ID" \
+        "CertificateArn=$CERTIFICATE_ARN" \
+        "ImageTag=$IMAGE_TAG" \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --no-fail-on-empty-changeset \
+    --region "$REGION"
+
+echo ""
+echo "▶ Stack outputs:"
+aws cloudformation describe-stacks \
+    --stack-name "$STACK_NAME" \
+    --region "$REGION" \
+    --query "Stacks[0].Outputs[*].[OutputKey, OutputValue]" \
+    --output table
+
+echo ""
+echo "✓ Deploy complete."

--- a/hls-ingest/infra/deploy.sh
+++ b/hls-ingest/infra/deploy.sh
@@ -110,7 +110,7 @@ fi
 
 echo ""
 echo "▶ Building Docker image..."
-docker build -t "$REPO_NAME:$IMAGE_TAG" "$SERVICE_DIR"
+docker build --platform linux/amd64 -t "$REPO_NAME:$IMAGE_TAG" "$SERVICE_DIR"
 
 echo ""
 echo "▶ Pushing to ECR..."

--- a/hls-ingest/infra/env.production.conf.example
+++ b/hls-ingest/infra/env.production.conf.example
@@ -4,10 +4,8 @@
 # To find these values:
 #   VPC_ID:          aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text
 #   SUBNET_IDS:      aws ec2 describe-subnets --filters Name=vpc-id,Values=<vpc-id> --query 'Subnets[*].SubnetId' --output text
-#   HOSTED_ZONE_ID:  aws route53 list-hosted-zones-by-name --dns-name wxyc.org --query 'HostedZones[0].Id' --output text
 #   CERTIFICATE_ARN: aws acm list-certificates --region us-east-1 --query 'CertificateSummaryList[?DomainName==`*.wxyc.org`].CertificateArn' --output text
 
 VPC_ID=vpc-xxxxxxxxx
 SUBNET_IDS=subnet-xxxxxxxx,subnet-yyyyyyyy
-HOSTED_ZONE_ID=ZXXXXXXXXXXXXX
 CERTIFICATE_ARN=arn:aws:acm:us-east-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/hls-ingest/infra/env.production.conf.example
+++ b/hls-ingest/infra/env.production.conf.example
@@ -1,0 +1,13 @@
+# AWS resource IDs for the production environment.
+# Copy this file to env.production.conf and fill in your values.
+#
+# To find these values:
+#   VPC_ID:          aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text
+#   SUBNET_IDS:      aws ec2 describe-subnets --filters Name=vpc-id,Values=<vpc-id> --query 'Subnets[*].SubnetId' --output text
+#   HOSTED_ZONE_ID:  aws route53 list-hosted-zones-by-name --dns-name wxyc.org --query 'HostedZones[0].Id' --output text
+#   CERTIFICATE_ARN: aws acm list-certificates --region us-east-1 --query 'CertificateSummaryList[?DomainName==`*.wxyc.org`].CertificateArn' --output text
+
+VPC_ID=vpc-xxxxxxxxx
+SUBNET_IDS=subnet-xxxxxxxx,subnet-yyyyyyyy
+HOSTED_ZONE_ID=ZXXXXXXXXXXXXX
+CERTIFICATE_ARN=arn:aws:acm:us-east-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/hls-ingest/infra/env.staging.conf.example
+++ b/hls-ingest/infra/env.staging.conf.example
@@ -4,10 +4,8 @@
 # To find these values:
 #   VPC_ID:          aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text
 #   SUBNET_IDS:      aws ec2 describe-subnets --filters Name=vpc-id,Values=<vpc-id> --query 'Subnets[*].SubnetId' --output text
-#   HOSTED_ZONE_ID:  aws route53 list-hosted-zones-by-name --dns-name wxyc.org --query 'HostedZones[0].Id' --output text
 #   CERTIFICATE_ARN: aws acm list-certificates --region us-east-1 --query 'CertificateSummaryList[?DomainName==`*.wxyc.org`].CertificateArn' --output text
 
 VPC_ID=vpc-xxxxxxxxx
 SUBNET_IDS=subnet-xxxxxxxx,subnet-yyyyyyyy
-HOSTED_ZONE_ID=ZXXXXXXXXXXXXX
 CERTIFICATE_ARN=arn:aws:acm:us-east-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/hls-ingest/infra/env.staging.conf.example
+++ b/hls-ingest/infra/env.staging.conf.example
@@ -1,0 +1,13 @@
+# AWS resource IDs for the staging environment.
+# Copy this file to env.staging.conf and fill in your values.
+#
+# To find these values:
+#   VPC_ID:          aws ec2 describe-vpcs --filters Name=isDefault,Values=true --query 'Vpcs[0].VpcId' --output text
+#   SUBNET_IDS:      aws ec2 describe-subnets --filters Name=vpc-id,Values=<vpc-id> --query 'Subnets[*].SubnetId' --output text
+#   HOSTED_ZONE_ID:  aws route53 list-hosted-zones-by-name --dns-name wxyc.org --query 'HostedZones[0].Id' --output text
+#   CERTIFICATE_ARN: aws acm list-certificates --region us-east-1 --query 'CertificateSummaryList[?DomainName==`*.wxyc.org`].CertificateArn' --output text
+
+VPC_ID=vpc-xxxxxxxxx
+SUBNET_IDS=subnet-xxxxxxxx,subnet-yyyyyyyy
+HOSTED_ZONE_ID=ZXXXXXXXXXXXXX
+CERTIFICATE_ARN=arn:aws:acm:us-east-1:123456789012:certificate/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx

--- a/hls-ingest/infra/template.yaml
+++ b/hls-ingest/infra/template.yaml
@@ -25,10 +25,6 @@ Parameters:
       One or more public subnets for the Fargate task. These must have
       internet access (either via an internet gateway or NAT).
 
-  HostedZoneId:
-    Type: AWS::Route53::HostedZone::Id
-    Description: Route 53 hosted zone ID for wxyc.org.
-
   CertificateArn:
     Type: String
     Description: >
@@ -196,18 +192,8 @@ Resources:
             AllowedMethods: [GET, HEAD, OPTIONS]
             Compress: true  # Playlists are text; compresses well.
 
-  # =========================================================================
-  # Route 53 — custom domain pointing to CloudFront
-  # =========================================================================
-  DNSRecord:
-    Type: AWS::Route53::RecordSet
-    Properties:
-      HostedZoneId: !Ref HostedZoneId
-      Name: !FindInMap [EnvConfig, !Ref Environment, DomainName]
-      Type: A
-      AliasTarget:
-        DNSName: !GetAtt CloudFrontDistribution.DomainName
-        HostedZoneId: Z2FDTNDATAQYW2  # CloudFront's fixed hosted zone ID
+  # DNS is managed in Cloudflare, not Route 53. After deploying, add a CNAME
+  # in Cloudflare pointing the domain to the CloudFrontDomain output value.
 
   # =========================================================================
   # IAM — roles for ECS tasks

--- a/hls-ingest/infra/template.yaml
+++ b/hls-ingest/infra/template.yaml
@@ -1,0 +1,357 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  WXYC HLS ingest service. Captures the ibiblio MP3 stream, segments it into
+  HLS via ffmpeg, and uploads to S3. Served via CloudFront with HTTPS.
+
+# ---------------------------------------------------------------------------
+# Parameters — these values change between staging and production deploys.
+# Run:  aws cloudformation deploy --parameter-overrides Environment=staging ...
+# ---------------------------------------------------------------------------
+Parameters:
+  Environment:
+    Type: String
+    AllowedValues:
+      - staging
+      - production
+    Description: Deployment environment (staging or production).
+
+  VpcId:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC for the Fargate task. The default VPC works fine.
+
+  SubnetIds:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: >
+      One or more public subnets for the Fargate task. These must have
+      internet access (either via an internet gateway or NAT).
+
+  HostedZoneId:
+    Type: AWS::Route53::HostedZone::Id
+    Description: Route 53 hosted zone ID for wxyc.org.
+
+  CertificateArn:
+    Type: String
+    Description: >
+      ACM certificate ARN covering hls.wxyc.org and hls-staging.wxyc.org.
+      Must be in us-east-1 (CloudFront requirement).
+
+  ImageTag:
+    Type: String
+    Default: latest
+    Description: Docker image tag to deploy from ECR.
+
+# ---------------------------------------------------------------------------
+# Mappings — values that differ between staging and production.
+# ---------------------------------------------------------------------------
+Mappings:
+  EnvConfig:
+    staging:
+      BucketName: wxyc-hls-staging
+      DomainName: hls-staging.wxyc.org
+      LifecycleDays: 1
+    production:
+      BucketName: wxyc-hls
+      DomainName: hls.wxyc.org
+      LifecycleDays: 2
+
+Resources:
+  # =========================================================================
+  # S3 — stores HLS segments (.ts) and playlist (.m3u8)
+  # =========================================================================
+  HLSBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !FindInMap [EnvConfig, !Ref Environment, BucketName]
+      VersioningConfiguration:
+        Status: Enabled
+      LifecycleConfiguration:
+        Rules:
+          - Id: expire-old-segments
+            Status: Enabled
+            Prefix: live/
+            ExpirationInDays: !FindInMap [EnvConfig, !Ref Environment, LifecycleDays]
+          - Id: expire-old-versions
+            Status: Enabled
+            Prefix: live/
+            NoncurrentVersionExpiration:
+              NoncurrentDays: 1
+      CorsConfiguration:
+        CorsRules:
+          - AllowedMethods: [GET, HEAD]
+            AllowedOrigins: ["*"]
+            AllowedHeaders: ["*"]
+            MaxAge: 3600
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  # Bucket policy: only CloudFront can read objects (via OAC).
+  HLSBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref HLSBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowCloudFrontOAC
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:GetObject
+            Resource: !Sub "${HLSBucket.Arn}/*"
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistribution}"
+
+  # =========================================================================
+  # CloudFront — HTTPS, caching, custom domain
+  # =========================================================================
+
+  # Origin Access Control: CloudFront signs requests to S3 with SigV4.
+  # This replaces the deprecated OAI (Origin Access Identity).
+  OriginAccessControl:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: !Sub "hls-ingest-oac-${Environment}"
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  # Cache policy for playlists: very short TTL so clients see new segments quickly.
+  PlaylistCachePolicy:
+    Type: AWS::CloudFront::CachePolicy
+    Properties:
+      CachePolicyConfig:
+        Name: !Sub "hls-playlist-${Environment}"
+        MinTTL: 1
+        DefaultTTL: 2
+        MaxTTL: 4
+        ParametersInCacheKeyAndForwardedToOrigin:
+          EnableAcceptEncodingGzip: true
+          HeadersConfig:
+            HeaderBehavior: none
+          CookiesConfig:
+            CookieBehavior: none
+          QueryStringsConfig:
+            QueryStringBehavior: none
+
+  # Cache policy for segments: long TTL since segments are immutable once written.
+  SegmentCachePolicy:
+    Type: AWS::CloudFront::CachePolicy
+    Properties:
+      CachePolicyConfig:
+        Name: !Sub "hls-segment-${Environment}"
+        MinTTL: 86400
+        DefaultTTL: 86400
+        MaxTTL: 86400
+        ParametersInCacheKeyAndForwardedToOrigin:
+          EnableAcceptEncodingGzip: false
+          HeadersConfig:
+            HeaderBehavior: none
+          CookiesConfig:
+            CookieBehavior: none
+          QueryStringsConfig:
+            QueryStringBehavior: none
+
+  CloudFrontDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        Comment: !Sub "WXYC HLS ${Environment}"
+        HttpVersion: http2and3
+        Aliases:
+          - !FindInMap [EnvConfig, !Ref Environment, DomainName]
+        ViewerCertificate:
+          AcmCertificateArn: !Ref CertificateArn
+          SslSupportMethod: sni-only
+          MinimumProtocolVersion: TLSv1.2_2021
+        Origins:
+          - Id: S3Origin
+            DomainName: !GetAtt HLSBucket.RegionalDomainName
+            S3OriginConfig:
+              OriginAccessIdentity: ""
+            OriginAccessControlId: !GetAtt OriginAccessControl.Id
+        # Default behavior: .ts segments (long cache).
+        DefaultCacheBehavior:
+          TargetOriginId: S3Origin
+          ViewerProtocolPolicy: redirect-to-https
+          CachePolicyId: !Ref SegmentCachePolicy
+          # Forward Origin header to S3 so CORS response headers are returned.
+          OriginRequestPolicyId: 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf  # Managed-CORS-S3Origin
+          AllowedMethods: [GET, HEAD, OPTIONS]
+          Compress: false  # Segments are compressed media; gzip wastes CPU.
+        # Override for .m3u8 playlists (short cache).
+        CacheBehaviors:
+          - PathPattern: "*.m3u8"
+            TargetOriginId: S3Origin
+            ViewerProtocolPolicy: redirect-to-https
+            CachePolicyId: !Ref PlaylistCachePolicy
+            OriginRequestPolicyId: 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf  # Managed-CORS-S3Origin
+            AllowedMethods: [GET, HEAD, OPTIONS]
+            Compress: true  # Playlists are text; compresses well.
+
+  # =========================================================================
+  # Route 53 — custom domain pointing to CloudFront
+  # =========================================================================
+  DNSRecord:
+    Type: AWS::Route53::RecordSet
+    Properties:
+      HostedZoneId: !Ref HostedZoneId
+      Name: !FindInMap [EnvConfig, !Ref Environment, DomainName]
+      Type: A
+      AliasTarget:
+        DNSName: !GetAtt CloudFrontDistribution.DomainName
+        HostedZoneId: Z2FDTNDATAQYW2  # CloudFront's fixed hosted zone ID
+
+  # =========================================================================
+  # IAM — roles for ECS tasks
+  # =========================================================================
+
+  # Execution role: lets ECS pull images from ECR and write to CloudWatch Logs.
+  TaskExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "hls-ingest-exec-${Environment}"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+
+  # Task role: lets the running container upload segments to S3.
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub "hls-ingest-task-${Environment}"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: S3UploadPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                Resource: !Sub "${HLSBucket.Arn}/*"
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: !GetAtt HLSBucket.Arn
+
+  # =========================================================================
+  # ECS — Fargate cluster, task definition, and service
+  # =========================================================================
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/ecs/hls-ingest-${Environment}"
+      RetentionInDays: 14
+
+  ECSCluster:
+    Type: AWS::ECS::Cluster
+    Properties:
+      ClusterName: !Sub "hls-ingest-${Environment}"
+
+  SecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: !Sub "hls-ingest ${Environment} - egress only"
+      VpcId: !Ref VpcId
+      SecurityGroupEgress:
+        - IpProtocol: "-1"
+          CidrIp: 0.0.0.0/0
+          Description: Allow all outbound (ibiblio stream, S3, ECR, CloudWatch)
+
+  TaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      Family: !Sub "hls-ingest-${Environment}"
+      NetworkMode: awsvpc
+      RequiresCompatibilities: [FARGATE]
+      Cpu: "256"     # 0.25 vCPU — plenty for 128kbps audio transcode
+      Memory: "512"  # 512 MB
+      ExecutionRoleArn: !GetAtt TaskExecutionRole.Arn
+      TaskRoleArn: !GetAtt TaskRole.Arn
+      ContainerDefinitions:
+        - Name: hls-ingest
+          Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/wxyc/hls-ingest:${ImageTag}"
+          Essential: true
+          Environment:
+            - Name: S3_BUCKET
+              Value: !FindInMap [EnvConfig, !Ref Environment, BucketName]
+            - Name: S3_PREFIX
+              Value: live
+            - Name: AWS_REGION
+              Value: !Ref "AWS::Region"
+          PortMappings:
+            - ContainerPort: 8090
+              Protocol: tcp
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group: !Ref LogGroup
+              awslogs-region: !Ref "AWS::Region"
+              awslogs-stream-prefix: hls-ingest
+          HealthCheck:
+            Command:
+              - CMD-SHELL
+              - "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8090/health')\""
+            Interval: 30
+            Timeout: 5
+            Retries: 3
+            StartPeriod: 30
+
+  ECSService:
+    Type: AWS::ECS::Service
+    Properties:
+      ServiceName: !Sub "hls-ingest-${Environment}"
+      Cluster: !Ref ECSCluster
+      TaskDefinition: !Ref TaskDefinition
+      DesiredCount: 1
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          Subnets: !Ref SubnetIds
+          SecurityGroups:
+            - !Ref SecurityGroup
+      # Stop-before-start: only one task writes to S3 at a time.
+      # Two concurrent ffmpeg instances would corrupt the playlist.
+      DeploymentConfiguration:
+        MinimumHealthyPercent: 0
+        MaximumPercent: 100
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+Outputs:
+  HLSUrl:
+    Description: HLS stream URL (paste into a player)
+    Value: !Sub
+      - "https://${Domain}/live/live.m3u8"
+      - Domain: !FindInMap [EnvConfig, !Ref Environment, DomainName]
+
+  CloudFrontDomain:
+    Description: CloudFront distribution domain name
+    Value: !GetAtt CloudFrontDistribution.DomainName
+
+  S3BucketName:
+    Description: S3 bucket for HLS segments
+    Value: !Ref HLSBucket

--- a/hls-ingest/main.py
+++ b/hls-ingest/main.py
@@ -37,13 +37,14 @@ def main() -> None:
     output_dir = tempfile.mkdtemp(prefix="hls-ingest-")
     logger.info("HLS output directory: %s", output_dir)
 
-    # Set up S3 client
-    s3_client = boto3.client(
-        "s3",
-        region_name=config.aws_region,
-        aws_access_key_id=config.aws_access_key_id,
-        aws_secret_access_key=config.aws_secret_access_key,
-    )
+    # Set up S3 client. When credentials are provided (local dev), pass them
+    # explicitly. When omitted (ECS Fargate), boto3 discovers them from the
+    # task role automatically.
+    s3_kwargs = {"region_name": config.aws_region}
+    if config.aws_access_key_id and config.aws_secret_access_key:
+        s3_kwargs["aws_access_key_id"] = config.aws_access_key_id
+        s3_kwargs["aws_secret_access_key"] = config.aws_secret_access_key
+    s3_client = boto3.client("s3", **s3_kwargs)
 
     # Set up components
     ingest = IngestProcess(config, output_dir)

--- a/hls-ingest/requirements-dev.txt
+++ b/hls-ingest/requirements-dev.txt
@@ -1,0 +1,7 @@
+-r requirements.txt
+pytest>=8.0,<9
+pytest-asyncio>=0.23,<1
+pytest-aiohttp>=1.0,<2
+moto[s3]>=5.0,<6
+black>=24.0
+ruff>=0.3

--- a/hls-ingest/requirements.txt
+++ b/hls-ingest/requirements.txt
@@ -1,9 +1,3 @@
 boto3>=1.34,<2
 watchdog>=4.0,<5
 aiohttp>=3.9,<4
-pytest>=8.0,<9
-pytest-asyncio>=0.23,<1
-pytest-aiohttp>=1.0,<2
-moto[s3]>=5.0,<6
-black>=24.0
-ruff>=0.3

--- a/hls-ingest/scripts/provision-aws.sh
+++ b/hls-ingest/scripts/provision-aws.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 #
+# DEPRECATED: This script is superseded by the CloudFormation template at
+# infra/template.yaml. Use infra/deploy.sh to provision and deploy.
+# This file is retained for reference during migration.
+#
 # Provision AWS resources for the HLS ingest service.
 #
 # Creates the S3 bucket with a lifecycle rule to expire old segments,

--- a/hls-ingest/tests/test_config.py
+++ b/hls-ingest/tests/test_config.py
@@ -38,17 +38,21 @@ class TestConfigFromEnv:
         assert config.hls_list_size == 600
         assert config.health_port == 8090
 
-    def test_missing_aws_key_raises(self, monkeypatch):
+    def test_no_aws_credentials_defaults_to_empty(self, monkeypatch):
+        """Credentials are optional; boto3 discovers them from IAM roles on Fargate."""
         monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
         monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
-        with pytest.raises(ValueError, match="AWS_ACCESS_KEY_ID"):
-            Config.from_env()
+        config = Config.from_env()
+        assert config.aws_access_key_id == ""
+        assert config.aws_secret_access_key == ""
 
-    def test_missing_secret_key_raises(self, monkeypatch):
+    def test_partial_credentials_still_succeeds(self, monkeypatch):
+        """Credential validation is deferred to boto3 at runtime, not config loading."""
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
         monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
-        with pytest.raises(ValueError, match="AWS_ACCESS_KEY_ID"):
-            Config.from_env()
+        config = Config.from_env()
+        assert config.aws_access_key_id == "AKIAIOSFODNN7EXAMPLE"
+        assert config.aws_secret_access_key == ""
 
     def test_custom_env_values(self, monkeypatch):
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")

--- a/hls-ingest/tests/test_uploader.py
+++ b/hls-ingest/tests/test_uploader.py
@@ -4,7 +4,7 @@ import os
 import queue
 from unittest.mock import MagicMock, call, patch
 
-from watchdog.events import FileClosedEvent, FileSystemEventHandler
+from watchdog.events import FileClosedEvent, FileMovedEvent, FileSystemEventHandler
 
 from uploader import (
     HLSUploadHandler,
@@ -158,6 +158,39 @@ class TestHLSUploadHandlerOnClosed:
 
         event = FileClosedEvent(txt_path)
         handler.on_closed(event)
+
+        assert q.empty()
+
+    def test_on_moved_enqueues_dest_m3u8(self, tmp_output_dir):
+        """ffmpeg updates playlists via atomic rename (.tmp -> .m3u8).
+
+        inotify delivers this as IN_MOVED_TO (FileMovedEvent), not
+        IN_CLOSE_WRITE (FileClosedEvent). The handler must enqueue the
+        destination path when it has an HLS extension.
+        """
+        q = queue.Queue()
+        handler = HLSUploadHandler(q)
+
+        src = os.path.join(tmp_output_dir, "live.m3u8.tmp")
+        dest = os.path.join(tmp_output_dir, "live.m3u8")
+        with open(dest, "w") as f:
+            f.write("#EXTM3U\n")
+
+        event = FileMovedEvent(src, dest)
+        handler.on_moved(event)
+
+        assert not q.empty()
+        assert q.get_nowait() == dest
+
+    def test_on_moved_ignores_non_hls_dest(self, tmp_output_dir):
+        q = queue.Queue()
+        handler = HLSUploadHandler(q)
+
+        src = os.path.join(tmp_output_dir, "data.tmp")
+        dest = os.path.join(tmp_output_dir, "data.txt")
+
+        event = FileMovedEvent(src, dest)
+        handler.on_moved(event)
 
         assert q.empty()
 

--- a/hls-ingest/uploader.py
+++ b/hls-ingest/uploader.py
@@ -1,9 +1,11 @@
 """S3 upload worker that watches for completed HLS files and uploads them.
 
-Uses watchdog's FileClosedEvent (inotify on Linux) to detect when ffmpeg
-finishes writing a segment or playlist, then uploads via a separate worker
-thread to avoid blocking the observer. Playlists are deferred until the
-queue drains, ensuring segments reach S3 before the playlist references them.
+Uses watchdog's FileClosedEvent (inotify IN_CLOSE_WRITE) for segments and
+FileMovedEvent (inotify IN_MOVED_TO) for playlists. ffmpeg writes playlists
+via atomic rename (.tmp -> .m3u8), so they arrive as move events, not close
+events. Uploads run in a separate worker thread to avoid blocking the
+observer. Playlists are deferred until the queue drains, ensuring segments
+reach S3 before the playlist references them.
 """
 
 import logging
@@ -13,7 +15,7 @@ import threading
 import time
 from typing import Protocol
 
-from watchdog.events import FileClosedEvent, FileSystemEventHandler
+from watchdog.events import FileClosedEvent, FileMovedEvent, FileSystemEventHandler
 from watchdog.observers import Observer
 
 logger = logging.getLogger(__name__)
@@ -112,11 +114,12 @@ def upload_with_retry(
 
 
 class HLSUploadHandler(FileSystemEventHandler):
-    """Watchdog handler that enqueues closed HLS files for upload.
+    """Watchdog handler that enqueues completed HLS files for upload.
 
-    Only responds to on_closed events (FileClosedEvent), ensuring files are
-    fully written before being queued. This requires inotify (Linux); the
-    production Docker container runs on Linux.
+    Responds to on_closed (FileClosedEvent) for segments written directly by
+    ffmpeg, and on_moved (FileMovedEvent) for playlists that ffmpeg updates
+    via atomic rename. Both require inotify (Linux); the production Docker
+    container runs on Linux.
     """
 
     def __init__(self, upload_queue: queue.Queue) -> None:
@@ -127,10 +130,23 @@ class HLSUploadHandler(FileSystemEventHandler):
         """Enqueue HLS files when they are closed after writing."""
         if event.is_directory:
             return
-        filename = os.path.basename(event.src_path)
+        self._enqueue_if_hls(event.src_path)
+
+    def on_moved(self, event: FileMovedEvent) -> None:
+        """Enqueue HLS files that arrive via atomic rename.
+
+        ffmpeg updates playlists by writing to a temp file then renaming
+        it. inotify delivers this as IN_MOVED_TO, not IN_CLOSE_WRITE.
+        """
+        if event.is_directory:
+            return
+        self._enqueue_if_hls(event.dest_path)
+
+    def _enqueue_if_hls(self, path: str) -> None:
+        filename = os.path.basename(path)
         _, ext = os.path.splitext(filename)
         if ext in CONTENT_TYPES:
-            self._queue.put(event.src_path)
+            self._queue.put(path)
 
 
 class UploadWorkerThread:


### PR DESCRIPTION
## Summary

- Add CloudFormation template (`hls-ingest/infra/template.yaml`) parameterized for staging and production: S3 bucket, CloudFront distribution with OAC and separate playlist/segment cache policies, ECS Fargate service, IAM roles, Route 53 DNS record, CloudWatch log group
- Add deploy script (`infra/deploy.sh`) that builds/pushes Docker image to ECR and deploys the stack
- Make AWS credentials optional in `config.py` so boto3 discovers them from ECS task roles on Fargate
- Split `requirements.txt` into runtime-only and `requirements-dev.txt` (slimmer production Docker image)
- Deprecate `scripts/provision-aws.sh` in favor of CloudFormation

Closes #5

## Test plan

- [x] 65 unit tests pass (`pytest -v`)
- [x] ruff lint passes
- [x] black format check passes
- [x] CloudFormation template validates (`aws cloudformation validate-template`)
- [x] Deploy script passes `bash -n` syntax check
- [ ] Deploy staging stack with `./infra/deploy.sh staging` and verify HLS playback at `https://hls-staging.wxyc.org/live/live.m3u8`